### PR TITLE
Fixed Issue #56, refresh of the page inserts duplicated appointments …

### DIFF
--- a/src/application/controllers/appointments.php
+++ b/src/application/controllers/appointments.php
@@ -207,20 +207,11 @@ class Appointments extends CI_Controller {
                 } catch(Exception $exc) {
                     $view['exceptions'][] = $exc;
                 }
-
-                // :: LOAD THE BOOK SUCCESS VIEW
-                $view = array(
-                    'appointment_data'  => $appointment,
-                    'provider_data'     => $provider,
-                    'service_data'      => $service,
-                    'company_name'      => $company_settings['company_name']
-                );
-
             } catch(Exception $exc) {
                 $view['exceptions'][] = $exc;
             }
-
-            $this->load->view('appointments/book_success', $view);
+            $this->session->set_flashdata('book_exceptions', $view['exceptions']);
+            redirect('appointments/book_success/'.$appointment['id']);
         }
     }
 
@@ -674,6 +665,39 @@ class Appointments extends CI_Controller {
                 'exceptions' => array(exceptionToJavaScript($exc))
             ));
         }
+    }
+    /**
+     * GET an specific appointment book and redirect to the success screen.
+     *
+     * @param int $appointment_id Contains the id of the appointment to retrieve.
+     */
+    public function book_success($appointment_id) {
+        //if the appointment id doesn't exist or zero redirect to index
+        if(!$appointment_id){
+            redirect('appointments');
+        }
+        $this->load->model('appointments_model');
+        $this->load->model('providers_model');
+        $this->load->model('services_model');
+        $this->load->model('settings_model');
+        //retrieve the data needed in the view
+        $appointment =  $this->appointments_model->get_row($appointment_id);
+        $provider = $this->providers_model->get_row($appointment['id_users_provider']);
+        $service = $this->services_model->get_row($appointment['id_services']);
+        $company_name = $this->settings_model->get_setting('company_name');
+        //get the exceptions
+        $exceptions = $this->session->flashdata('book_success');
+         // :: LOAD THE BOOK SUCCESS VIEW
+        $view = array(
+            'appointment_data'  => $appointment,
+            'provider_data'     => $provider,
+            'service_data'      => $service,
+            'company_name'      => $company_name,
+        );
+        if($exceptions){
+            $view['exceptions'] = $exceptions;
+        }
+        $this->load->view('appointments/book_success', $view);
     }
 }
 

--- a/src/application/views/appointments/book_success.php
+++ b/src/application/views/appointments/book_success.php
@@ -44,6 +44,7 @@
                     <?php 
                         echo '<h3>' . $this->lang->line('appointment_registered') . '</h3>'; 
                         echo '<p>' . $this->lang->line('appointment_details_was_sent_to_you') . '</p>';
+                        echo '<p><a href="'.$this->config->item('base_url').'">Book a new appointment</a></p>';
 
                         if ($this->config->item('ea_google_sync_feature')) { 
                             echo '

--- a/src/application/views/appointments/book_success.php
+++ b/src/application/views/appointments/book_success.php
@@ -44,8 +44,9 @@
                     <?php 
                         echo '<h3>' . $this->lang->line('appointment_registered') . '</h3>'; 
                         echo '<p>' . $this->lang->line('appointment_details_was_sent_to_you') . '</p>';
-                        echo '<p><a href="'.$this->config->item('base_url').'">Book a new appointment</a></p>';
-
+                        echo '<a href="'.$this->config->item('base_url').'" class="btn btn-primary btn-large">
+                            <span class="glyphicon glyphicon-calendar"></span>'.$this->lang->line('go_to_booking_page').'</a>';
+                        
                         if ($this->config->item('ea_google_sync_feature')) { 
                             echo '
                                 <button id="add-to-google-calendar" class="btn btn-primary">


### PR DESCRIPTION
Fixed the issue when refreshing the page at the last step of the book appointment wizard, it was inserting duplicated appointments. I followed the PRG pattern to solve this issue, its always a good practice when submitting forms to redirect to a new screen after the POST. Refer to: https://en.wikipedia.org/wiki/Post/Redirect/Get

I created a new GET method in the appointments controller (book_success), then after the POST I redirect to that GET method which will be accessed every time the user refreshes the screen. I also added a new link at the last step of the book appointment wizard so that the user can go back and book a new appointment. Just in case they want to.