### PR TITLE
Fix JS error (dialog() not a function)

### DIFF
--- a/src/application/views/user/forgot_password.php
+++ b/src/application/views/user/forgot_password.php
@@ -16,6 +16,9 @@
         src="<?php echo base_url('assets/ext/bootstrap/js/bootstrap.min.js'); ?>"></script>
     <script
         type="text/javascript"
+        src="<?php echo base_url('assets/ext/jquery-ui/jquery-ui.min.js'); ?>"></script>
+    <script
+        type="text/javascript"
         src="<?php echo base_url('assets/ext/datejs/date.js'); ?>"></script>
 
     <script type="text/javascript">
@@ -27,6 +30,10 @@
         rel="stylesheet"
         type="text/css"
         href="<?php echo base_url('assets/ext/bootstrap/css/bootstrap.min.css'); ?>">
+    <link
+        rel="stylesheet"
+        type="text/css"
+        href="<?php echo base_url('assets/ext/jquery-ui/jquery-ui.min.css'); ?>">
 
     <?php // SET FAVICON FOR PAGE ?>
     <link


### PR DESCRIPTION
Appears jquery-ui js & css omitted, but required for $(‘#messagebox’).dialog() calls.