### PR TITLE
 Limit  number of returned customers.

### DIFF
--- a/src/application/models/Customers_model.php
+++ b/src/application/models/Customers_model.php
@@ -358,7 +358,7 @@ class Customers_Model extends CI_Model {
             $this->db->where($where_clause);
         }
 
-        $this->db->where('id_roles', $customers_role_id);
+        $this->db->where('id_roles', $customers_role_id)->limit(50);
 
         return $this->db->get('ea_users')->result_array();
     }


### PR DESCRIPTION
    When the list of customers grows too long, the application slows down
    severely or crashes because of lack of memory.  This change limits the
    result size to max 50, which is plenty more than any of our users
    wanted.

   This is my first pull request ever.  I hope the formatting is all right. 