### PR TITLE
Fix database migration and creation scripts to stick with 1.3.1 changes

### DIFF
--- a/src/application/migrations/009_change_column_types.php
+++ b/src/application/migrations/009_change_column_types.php
@@ -31,22 +31,26 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11',
                 'auto_increment' => TRUE
             ],
             'id_users_provider' => [
                 'name' => 'id_users_provider',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ],
             'id_users_customer' => [
                 'name' => 'id_users_customer',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ],
             'id_services' => [
                 'name' => 'id_services',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ]
         ];
@@ -58,6 +62,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11',
                 'auto_increment' => TRUE
             ],
@@ -100,11 +105,13 @@ class Migration_Change_column_types extends CI_Migration {
             'id_users_secretary' => [
                 'name' => 'id_users_secretary',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ],
             'id_users_provider' => [
                 'name' => 'id_users_provider',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ]
         ];
@@ -116,12 +123,14 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11',
                 'auto_increment' => TRUE
             ],
             'id_service_categories' => [
                 'name' => 'id_service_categories',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ]
         ];
@@ -133,11 +142,13 @@ class Migration_Change_column_types extends CI_Migration {
             'id_users' => [
                 'name' => 'id_users',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ],
             'id_services' => [
                 'name' => 'id_services',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ]
         ];
@@ -149,6 +160,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11',
                 'auto_increment' => TRUE
             ]
@@ -161,6 +173,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11',
                 'auto_increment' => TRUE
             ]
@@ -173,12 +186,15 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11',
                 'auto_increment' => TRUE
             ],
             'id_roles' => [
                 'name' => 'id_roles',
                 'type' => 'int',
+                'unsigned' => TRUE,
+                'null' => FALSE,
                 'constraint' => '11'
             ]
         ];
@@ -190,6 +206,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id_users' => [
                 'name' => 'id_users',
                 'type' => 'int',
+                'unsigned' => TRUE,
                 'constraint' => '11'
             ]
         ];
@@ -218,6 +235,9 @@ class Migration_Change_column_types extends CI_Migration {
 
         $this->db->query('ALTER TABLE `ea_user_settings`
             ADD CONSTRAINT `ea_user_settings_ibfk_1` FOREIGN KEY (`id_users`) REFERENCES `ea_users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE');
+        
+        // Change charset of ea_secretaries_providers table for databases created with EA! 1.2.1 version
+        $this->db->query('ALTER TABLE ea_secretaries_providers CONVERT TO CHARACTER SET utf8');
     }
 
     public function down()
@@ -239,22 +259,26 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20',
                 'auto_increment' => TRUE
             ],
             'id_users_provider' => [
                 'name' => 'id_users_provider',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ],
             'id_users_customer' => [
                 'name' => 'id_users_customer',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ],
             'id_services' => [
                 'name' => 'id_services',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ]
         ];
@@ -267,6 +291,7 @@ class Migration_Change_column_types extends CI_Migration {
                 'name' => 'id',
                 'type' => 'bigint',
                 'constraint' => '20',
+                'unsigned' => TRUE,
                 'auto_increment' => TRUE
             ],
             'appointments' => [
@@ -308,28 +333,32 @@ class Migration_Change_column_types extends CI_Migration {
             'id_users_secretary' => [
                 'name' => 'id_users_secretary',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ],
             'id_users_provider' => [
                 'name' => 'id_users_provider',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ]
         ];
 
-        $this->dbforge->modify_column('ea_roles', $fields);
+        $this->dbforge->modify_column('ea_secretaries_providers', $fields);
 
         // Services
         $fields = [
             'id' => [
                 'name' => 'id',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20',
                 'auto_increment' => TRUE
             ],
             'id_service_categories' => [
                 'name' => 'id_service_categories',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ]
         ];
@@ -341,11 +370,13 @@ class Migration_Change_column_types extends CI_Migration {
             'id_users' => [
                 'name' => 'id_users',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ],
             'id_services' => [
                 'name' => 'id_services',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ]
         ];
@@ -357,6 +388,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20',
                 'auto_increment' => TRUE
             ]
@@ -369,6 +401,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20',
                 'auto_increment' => TRUE
             ]
@@ -381,12 +414,15 @@ class Migration_Change_column_types extends CI_Migration {
             'id' => [
                 'name' => 'id',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20',
                 'auto_increment' => TRUE
             ],
             'id_roles' => [
                 'name' => 'id',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
+                'null' => FALSE,
                 'constraint' => '20'
             ]
         ];
@@ -398,6 +434,7 @@ class Migration_Change_column_types extends CI_Migration {
             'id_users' => [
                 'name' => 'id_users',
                 'type' => 'bigint',
+                'unsigned' => TRUE,
                 'constraint' => '20'
             ]
         ];

--- a/src/application/migrations/011_remove_prefix_from_fkey_constraints.php
+++ b/src/application/migrations/011_remove_prefix_from_fkey_constraints.php
@@ -68,6 +68,10 @@ class Migration_Remove_prefix_from_fkey_constraints extends CI_Migration {
             ADD CONSTRAINT `user_settings_users` FOREIGN KEY (`id_users`) REFERENCES `ea_users` (`id`)
             ON DELETE CASCADE
             ON UPDATE CASCADE');
+                                
+        // The name of these indexes changed in the file structure.sql of EA! 1.3.1 so we need to update it
+        $this->db->query('ALTER TABLE ea_secretaries_providers DROP KEY fk_ea_secretaries_providers_1, ADD KEY id_users_secretary (id_users_secretary)');
+        $this->db->query('ALTER TABLE ea_secretaries_providers DROP KEY fk_ea_secretaries_providers_2, ADD KEY id_users_provider (id_users_provider)');
     }
 
     public function down()

--- a/src/assets/sql/structure.sql
+++ b/src/assets/sql/structure.sql
@@ -2,16 +2,16 @@ SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
 
 CREATE TABLE IF NOT EXISTS `ea_appointments` (
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `book_datetime` DATETIME,
     `start_datetime` DATETIME,
     `end_datetime` DATETIME,
     `notes` TEXT,
     `hash` TEXT,
     `is_unavailable` TINYINT(4) DEFAULT '0',
-    `id_users_provider` BIGINT(20) UNSIGNED,
-    `id_users_customer` BIGINT(20) UNSIGNED,
-    `id_services` BIGINT(20) UNSIGNED,
+    `id_users_provider` INT(11) UNSIGNED,
+    `id_users_customer` INT(11) UNSIGNED,
+    `id_services` INT(11) UNSIGNED,
     `id_google_calendar` TEXT,
     PRIMARY KEY (`id`),
     KEY `id_users_customer` (`id_users_customer`),
@@ -29,15 +29,15 @@ CREATE TABLE `ea_migrations` (
     DEFAULT CHARSET = utf8;
 
 CREATE TABLE IF NOT EXISTS `ea_roles` (
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(256),
     `slug` VARCHAR(256),
     `is_admin` TINYINT(4),
-    `appointments` INT(4),
-    `customers` INT(4),
-    `services` INT(4),
-    `users` INT(4),
-    `system_settings` INT(4),
+    `appointments` INT(11),
+    `customers` INT(11),
+    `services` INT(11),
+    `users` INT(11),
+    `system_settings` INT(11),
     `user_settings` INT(11),
     PRIMARY KEY (`id`)
 )
@@ -46,8 +46,8 @@ CREATE TABLE IF NOT EXISTS `ea_roles` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_secretaries_providers` (
-    `id_users_secretary` BIGINT(20) UNSIGNED NOT NULL,
-    `id_users_provider` BIGINT(20) UNSIGNED NOT NULL,
+    `id_users_secretary` INT(11) UNSIGNED NOT NULL,
+    `id_users_provider` INT(11) UNSIGNED NOT NULL,
     PRIMARY KEY (`id_users_secretary`, `id_users_provider`),
     KEY `id_users_secretary` (`id_users_secretary`),
     KEY `id_users_provider` (`id_users_provider`)
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS `ea_secretaries_providers` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_services` (
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(256),
     `duration` INT(11),
     `price` DECIMAL(10, 2),
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS `ea_services` (
     `description` TEXT,
     `availabilities_type` VARCHAR(32) DEFAULT 'flexible',
     `attendants_number` INT(11) DEFAULT '1',
-    `id_service_categories` BIGINT(20) UNSIGNED,
+    `id_service_categories` INT(11) UNSIGNED,
     PRIMARY KEY (`id`),
     KEY `id_service_categories` (`id_service_categories`)
 )
@@ -74,8 +74,8 @@ CREATE TABLE IF NOT EXISTS `ea_services` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_services_providers` (
-    `id_users` BIGINT(20) UNSIGNED NOT NULL,
-    `id_services` BIGINT(20) UNSIGNED NOT NULL,
+    `id_users` INT(11) UNSIGNED NOT NULL,
+    `id_services` INT(11) UNSIGNED NOT NULL,
     PRIMARY KEY (`id_users`, `id_services`),
     KEY `id_services` (`id_services`)
 )
@@ -84,7 +84,7 @@ CREATE TABLE IF NOT EXISTS `ea_services_providers` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_service_categories` (
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(256),
     `description` TEXT,
     PRIMARY KEY (`id`)
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS `ea_service_categories` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_settings` (
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(512),
     `value` LONGTEXT,
     PRIMARY KEY (`id`)
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS `ea_settings` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_users` (
-    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `first_name` VARCHAR(256),
     `last_name` VARCHAR(512),
     `email` VARCHAR(512),
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS `ea_users` (
     `state` VARCHAR(128),
     `zip_code` VARCHAR(64),
     `notes` TEXT,
-    `id_roles` BIGINT(20) UNSIGNED NOT NULL,
+    `id_roles` INT(11) UNSIGNED NOT NULL,
     PRIMARY KEY (`id`),
     KEY `id_roles` (`id_roles`)
 )
@@ -124,7 +124,7 @@ CREATE TABLE IF NOT EXISTS `ea_users` (
 
 
 CREATE TABLE IF NOT EXISTS `ea_user_settings` (
-    `id_users` BIGINT(20) UNSIGNED NOT NULL,
+    `id_users` INT(11) UNSIGNED NOT NULL,
     `username` VARCHAR(256),
     `password` VARCHAR(512),
     `salt` VARCHAR(512),

--- a/src/system/libraries/Migration.php
+++ b/src/system/libraries/Migration.php
@@ -167,7 +167,7 @@ class CI_Migration {
 		if ( ! $this->db->table_exists($this->_migration_table))
 		{
 			$this->dbforge->add_field(array(
-				'version' => array('type' => 'BIGINT', 'constraint' => 20),
+				'version' => array('type' => 'INT', 'constraint' => 11),
 			));
 
 			$this->dbforge->create_table($this->_migration_table, TRUE);


### PR DESCRIPTION
If we migrate a 1.2.1 database to 1.3.1 version, the structure is not the same as stated in `structure.sql`.
Differences seen between both versions of the database are mainly different integer size : `BIGINT` instead of `INT `for ids and key names.

The fix proposal consists in:

- `unsigned` has been added to most of the ids to keep this attribute;
- The charset of ea_secretaries_providers  table has been fixed after the 1.2.1, so we change it in 009 migration file to apply this fix;
- 2 key names in `ea_secretaries_providers `were changed in `structure.sql` in the commit d23ec0483cde47010869f0445d91b7104ed3079a. So the migration script has been updated to set the correct names;
- In 009 migration script, the column types were changed from `BIGINT(20) `to `INT(11)`. So the `structure.sql` file has been updated to stick with these changes.
