### PR TITLE
Fix down procedure for Secretary Provider

### DIFF
--- a/src/application/migrations/009_change_column_types.php
+++ b/src/application/migrations/009_change_column_types.php
@@ -320,7 +320,7 @@ class Migration_Change_column_types extends CI_Migration {
             ]
         ];
 
-        $this->dbforge->modify_column('ea_roles', $fields);
+        $this->dbforge->modify_column('ea_secretaries_providers', $fields);
 
         // Services
         $fields = [


### PR DESCRIPTION
Hi Alex,

You manually merged my initial pull request to fix the DB migration file (#493) to avoid the changes I suggested for the unsigned integers. However, I am afraid you missed a fix in the down function for the Secretary Provider data.

For the secretary provider down function, the modify_column is wrongly applied to the ea_roles table whereas it should be applied to the ea_secretaries_providers table.

For your convenience, please find a patch in a dedicated patch branch in line with the top of your develop branch.

Hope it helps.