### PR TITLE
Disable smtp certificate check

### DIFF
--- a/src/application/config/email.php
+++ b/src/application/config/email.php
@@ -12,3 +12,4 @@ $config['mailtype'] = 'html'; // or 'text'
 // $config['smtp_pass'] = '';
 // $config['smtp_crypto'] = 'ssl'; // or 'tls'
 // $config['smtp_port'] = 25;
+// $config['disable_certificate_check'] = false

--- a/src/engine/Notifications/Email.php
+++ b/src/engine/Notifications/Email.php
@@ -327,11 +327,10 @@ class Email {
      */
     protected function _createMailer()
     {
-        $mailer = new \PHPMailer;        
+        $mailer = new \PHPMailer;
 
         if ($this->config['protocol'] === 'smtp')
         {
-        	$mailer->SMTPDebug  = 3;
             $mailer->isSMTP();
             $mailer->Host = $this->config['smtp_host'];
             $mailer->SMTPAuth = TRUE;

--- a/src/engine/Notifications/Email.php
+++ b/src/engine/Notifications/Email.php
@@ -327,10 +327,11 @@ class Email {
      */
     protected function _createMailer()
     {
-        $mailer = new \PHPMailer;
+        $mailer = new \PHPMailer;        
 
         if ($this->config['protocol'] === 'smtp')
         {
+        	$mailer->SMTPDebug  = 3;
             $mailer->isSMTP();
             $mailer->Host = $this->config['smtp_host'];
             $mailer->SMTPAuth = TRUE;
@@ -338,6 +339,17 @@ class Email {
             $mailer->Password = $this->config['smtp_pass'];
             $mailer->SMTPSecure = $this->config['smtp_crypto'];
             $mailer->Port = $this->config['smtp_port'];
+            
+            if ( $this->config['disable_certificate_check'] )
+            {
+            	$mailer->SMTPOptions = array(
+            			'ssl' => array(
+            					'verify_peer' => false,
+            					'verify_peer_name' => false,
+            					'allow_self_signed' => true
+            			)
+            	);
+            }
         }
 
         $mailer->IsHTML($this->config['mailtype'] === 'html');


### PR DESCRIPTION
Hi all,

just a little code to enable using SMTP server configured to accept only secure connections but with a self signed certificate. ( this is the actual smtp server configuration in my environment )

It adds an entry in _src/application/config/email.php_ where it's possible to enable / disable this feature
Once enabled, the $mailer instance in _src/engine/Notifications/Email.php_ is configured to not verify peer, not verify peer name and allow self signed certificate by using the PHPMailer api.

Maybe can be helpful for other developers in such situation.