### PR TITLE
Fix display of breaks for working plans starting by Monday (Proposal for #506)

### DIFF
--- a/src/assets/js/backend_calendar_default_view.js
+++ b/src/assets/js/backend_calendar_default_view.js
@@ -801,8 +801,12 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
             if (filterType === FILTER_TYPE_PROVIDER && calendarView !== 'month') {
                 $.each(GlobalVariables.availableProviders, function (index, provider) {
                     if (provider.id == recordId) {
-                        var workingPlan = jQuery.parseJSON(provider.settings.working_plan);
+                        var workingPlan={};
+                        var workingPlanBulk = jQuery.parseJSON(provider.settings.working_plan);
                         var unavailablePeriod;
+
+                        // Sort the working plan starting with the first day as set in General settings to correctly align breaks in the calendar display
+                        workingPlan = GeneralFunctions.sortWeekDict(workingPlanBulk,0); // 0 is the ID for Sunday
 
                         switch (calendarView) {
                             case 'agendaDay':

--- a/src/assets/js/backend_calendar_default_view.js
+++ b/src/assets/js/backend_calendar_default_view.js
@@ -805,7 +805,7 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                         var workingPlanBulk = jQuery.parseJSON(provider.settings.working_plan);
                         var unavailablePeriod;
 
-                        // Sort the working plan starting with the first day as set in General settings to correctly align breaks in the calendar display
+                        // Sort the working plan starting with Sunday as the first weekday to correctly align breaks in the calendar display
                         workingPlan = GeneralFunctions.sortWeekDict(workingPlanBulk,0); // 0 is the ID for Sunday
 
                         switch (calendarView) {

--- a/src/assets/js/general_functions.js
+++ b/src/assets/js/general_functions.js
@@ -431,4 +431,71 @@ window.GeneralFunctions = window.GeneralFunctions || {};
         return result;
     };
 
+    /**
+     * Get the name in lowercase of a Weekday using its Id.
+     *
+     * @param {Integer} weekDayId The Id (From 0 for sunday to 6 for saturday).
+
+     * @return {String} Returns the name of the weekday.
+     */
+    exports.getWeekDayName = function (weekDayId) {
+        var result;
+
+        switch (weekDayId) {
+
+            case 0:
+                result = 'sunday';
+                break;
+
+            case 1:
+                result = 'monday';
+                break;
+
+            case 2:
+                result = 'tuesday';
+                break;
+
+            case 3:
+                result = 'wednesday';
+                break;
+
+            case 4:
+                result = 'thursday';
+                break;
+
+            case 5:
+                result = 'friday';
+                break;                
+
+            case 6:
+                result = 'saturday';
+                break;                
+                
+            default:
+                throw new Error('Invalid weekday Id provided!', weekDayId);
+        }
+
+        return result;
+    };
+
+    /**
+     * Sort a dictionary where keys are weekdays
+     *
+     * @param {Object} weekDict A dictionnary with weekdays as keys.
+     * @param {Integer} startDayId Id of the first day to start sorting (From 0 for sunday to 6 for saturday).
+
+     * @return {Object} Returns a sorted dictionary
+     */
+    exports.sortWeekDict = function (weekDict, startDayId) {
+        var sortedWeekDict={};
+
+        for (var i = startDayId; i < startDayId+7; i++)
+        {
+            var weekDayname = GeneralFunctions.getWeekDayName(i%7);
+            sortedWeekDict[weekDayname] = weekDict[weekDayname];
+        }
+        
+        return sortedWeekDict;
+    };
+
 })(window.GeneralFunctions);

--- a/src/assets/js/working_plan.js
+++ b/src/assets/js/working_plan.js
@@ -45,7 +45,10 @@
      * @param {Object} workingPlan Contains the working hours and breaks for each day of the week.
      */
     WorkingPlan.prototype.setup = function (workingPlan) {
-        $.each(workingPlan, function (index, workingDay) {
+        // Always displaying breaks with Sunday as the first day to be consistent with what is done in the the working plan view.
+        var workingPlanSorted = GeneralFunctions.sortWeekDict(workingPlan,0); // 0 is the ID for Sunday
+        
+        $.each(workingPlanSorted, function (index, workingDay) {
             if (workingDay != null) {
                 $('#' + index).prop('checked', true);
                 $('#' + index + '-start').val(Date.parse(workingDay.start).toString(GlobalVariables.timeFormat  === 'regular' ? 'h:mm tt' : 'HH:mm').toUpperCase());


### PR DESCRIPTION
Hi Alex,

Prior commit 00372f2f1af96df0d4545053ae6f27834e109ea6, the first weekday was Monday.
After this commit, it is set to Sunday and the display of breaks in the backend calendar is broken for former working plans as I recorded in Issue #506.

For a database created before this commit, working plans are stored with Monday as the first weekday.
Thus, when displaying the backend calendar, the system displays Monday breaks in the column of Sunday, Tuesday breaks in the column of Monday, and so on...

The fix consists in:
- Reordering the working plan elements with Sunday as the first day prior displaying the backend calendar.
- Also reordering the working plan elements when displaying 'Settings/Business Logic' and 'Users/Providers' tabs. This is to ensure that breaks are always displayed with Sunday first, like done for the Working Plan in those tabs, for consistency purpose.

Instead of dynamically reordering the working plans at run time, a different fix would be to reorder all the working plans (company + service provider) in database once for all, through a migration class.

But I noticed that you created Issue #471 to allow users to change the first weekday through a system wide setting. Changing the first weekday dynamically would then require to reorder all the working plans in database. This could be time consuming due to database writes in case of numerous service providers.

What do you think about my proposal?