### PR TITLE
Check for NULL events when syncing with Google Calendar

### DIFF
--- a/src/application/controllers/Google.php
+++ b/src/application/controllers/Google.php
@@ -219,7 +219,7 @@ class Google extends CI_Controller {
             foreach ($events->getItems() as $event)
             {
                 $results = $this->appointments_model->get_batch(['id_google_calendar' => $event->getId()]);
-                if (count($results) == 0)
+                if ((count($results) == 0) && !is_null($event) && !is_null($event->start) && !is_null($event->end))
                 {
                     // Record doesn't exist in E!A, so add the event now.
                     $appointment = [


### PR DESCRIPTION
fter collecting events from Google Calendar, and before adding them to E!A the change checks that the event start and end date aren't NULL. This causes the program to skip any offending events.

Generally these events cannot be seen on your Google Calendar and also cannot be deleted.