### PR TITLE
Patch for close buttons language in modal views

### DIFF
--- a/src/application/views/appointments/cookie_notice_modal.php
+++ b/src/application/views/appointments/cookie_notice_modal.php
@@ -9,7 +9,7 @@
                 <p><?= $cookie_notice_content ?></p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal"><?= lang('close') ?></button>
             </div>
         </div>
     </div>

--- a/src/application/views/appointments/privacy_policy_modal.php
+++ b/src/application/views/appointments/privacy_policy_modal.php
@@ -9,7 +9,7 @@
                 <p><?= $privacy_policy_content ?></p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal"><?= lang('close') ?></button>
             </div>
         </div>
     </div>

--- a/src/application/views/appointments/terms_and_conditions_modal.php
+++ b/src/application/views/appointments/terms_and_conditions_modal.php
@@ -9,7 +9,7 @@
                 <p><?= $terms_and_conditions_content ?></p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal"><?= lang('close') ?></button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Hi!

The language of the close button in every modal views (Terms & Conditions, Privacy Policy and Cookie Notice) was only in English.  I made it dynamic using selected language.

Thank you so much for your work!