### PR TITLE
Wrong datetime in appointment modal view in Safari

### DIFF
--- a/src/assets/js/backend_calendar_default_view.js
+++ b/src/assets/js/backend_calendar_default_view.js
@@ -1136,8 +1136,9 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                 }
 
                 // Preselect time
-                $('#start-datetime').datepicker('setDate', new Date(start.format('YYYY-MM-DD HH:mm:ss')));
-                $('#end-datetime').datepicker('setDate', new Date(end.format('YYYY-MM-DD HH:mm:ss')));
+                $('#start-datetime').datepicker('setDate', new Date(start.format('YYYY/MM/DD HH:mm:ss')));
+                // end-datetime : service.duration - 5 because normally the datepicker end time is shifted of 5 minutes forward
+                $('#end-datetime').datepicker('setDate', new Date(end.add(service.duration - 5, 'm').format('YYYY/MM/DD HH:mm:ss')));
 
                 return false;
             },


### PR DESCRIPTION
Bug fix

After clicking on a time slot in calendar default view, Easy!Appointments shows an appointment modal view with precompiled datepickers based on selected slot.

On all browser, except in Safari, all works great. **_Safari doesn't recognize the format of the given date_** and set a wrong date on datepickers.

This is due to a non-standard date format: 'YYYY-MM-DD HH:mm:ss'.

With this format: 'YYYY/MM/DD HH:mm:ss' the correct behavior of Easy!Appointments is reached even on Safari.

Furthermore, I have _**added to end-datetime the duration of the predefined service**_ .

Thank you so much for your work!