### PR TITLE
end-datetime accordingly with start and service

### DIFF
--- a/src/assets/js/backend_calendar_appointments_modal.js
+++ b/src/assets/js/backend_calendar_appointments_modal.js
@@ -423,7 +423,19 @@ window.BackendCalendarAppointmentsModal = window.BackendCalendarAppointmentsModa
             timeText: EALang.time,
             hourText: EALang.hour,
             minuteText: EALang.minutes,
-            firstDay: 0
+            firstDay: 0,
+            onClose: function () {
+                 var sid = $('#select-service').val();
+
+                 // Automatically update the #end-datetime DateTimePicker based on service duration.
+                 $.each(GlobalVariables.availableServices, function (indexService, service) {
+                     if (service.id == sid) {
+                         var start = $('#start-datetime').datetimepicker('getDate');
+                         $('#end-datetime').datetimepicker('setDate', new Date(start.getTime() + service.duration * 60000));
+                         return false; // break loop
+                     }
+                 });
+             }
         });
         $dialog.find('#start-datetime').datetimepicker('setDate', startDatetime);
 


### PR DESCRIPTION
New feature

I have updated Easy!Appointments to ensure that when #start-datetime DateTimePicker closes, it also updates the #end-datetime field according to the selected service.

Have a nice day!