### PR TITLE
Check against the Book Advance Timeout for all days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ developers to maintain and readjust their custom modifications on the main proje
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.3.2] - Unreleased
+## [1.3.2]
 
 ## Fixed
 

--- a/src/application/controllers/Appointments.php
+++ b/src/application/controllers/Appointments.php
@@ -402,14 +402,14 @@ class Appointments extends CI_Controller {
             // If the selected date is today, remove past hours. It is important  include the timeout before
             // booking that is set in the back-office the system. Normally we might want the customer to book
             // an appointment that is at least half or one hour from now. The setting is stored in minutes.
-            if (date('Y-m-d', strtotime($this->input->post('selected_date'))) === date('Y-m-d'))
+            $bookAdvanceTimeout = $this->settings_model->get_setting('book_advance_timeout');
+            $current_hour = strtotime('+' . $bookAdvanceTimeout . ' minutes', strtotime('now'));
+            if (strtotime($this->input->post('selected_date')) <= $current_hour)
             {
-                $book_advance_timeout = $this->settings_model->get_setting('book_advance_timeout');
-
                 foreach ($available_hours as $index => $value)
                 {
                     $available_hour = strtotime($value);
-                    $current_hour = strtotime('+' . $book_advance_timeout . ' minutes', strtotime('now'));
+                    
                     if ($available_hour <= $current_hour)
                     {
                         unset($available_hours[$index]);


### PR DESCRIPTION
Changed the src/application/controllers/Appointments.php file.

Check against the Book Advance Timeout for all days, so when the Timeout (Minutes) value is sufficiently large, business logic can force appoint scheduling several days in advance.

This makes it possible to create a 24-hour, 48-hour, or 1-week buffer for scheduling appointments.