### PR TITLE
Automatically detect the client's language

### DIFF
--- a/src/application/config/config.php
+++ b/src/application/config/config.php
@@ -82,7 +82,38 @@ $config['url_suffix'] = '';
 |
 */
 
-$config['language'] = defined('Config::LANGUAGE') ? Config::LANGUAGE : 'english';
+$config['language']	= 	(null !== $_SERVER['HTTP_ACCEPT_LANGUAGE']
+							?
+							array(
+								'ar' => 'arabic',
+								'bu' => 'bulgarian',
+								'zh' => 'chinese',
+								'da' => 'danish',
+								'nl' => 'dutch',
+								'en' => 'english',
+								'fi' => 'finnish',
+								'fr' => 'french',
+								'de' => 'german',
+								'el' => 'greek',
+								'hi' => 'hindi',
+								'hu' => 'hungarian',
+								'it' => 'italian',
+								'ja' => 'japanese',
+								'pl' => 'polish',
+								'pt' => 'portuguese',
+								'pt' => 'portuguese',
+								'ro' => 'romanian',
+								'ru' => 'russian',
+								'sk' => 'slovak',
+								'es' => 'spanish',
+								'tr' => 'turkish'
+							)[substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2)]
+							:
+							(defined('Config::LANGUAGE')
+								? Config::LANGUAGE
+								: 'english'
+							)
+						);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Load the frontend in the primary language of the client's browser, unless the end-user has overridden it using the language control of the footer.

Automatic detection will be overridden if a user's manual language selection has been saved in the session cookie.

Note that this implementation does not discriminate between languages classified, for better or worse, as variants. It does not distinguish German from Luxembourgish, for instance, whose RFC codes are `de` and `de-lu` respectively. I opted for this compromise because its implementation is contained within a few lines of code. Considering the flexibility of the [IETF/BCP language-tag scheme](https://tools.ietf.org/html/bcp47#appendix-A), a solution discriminating between all possible sequences of language and dialect subtags would be difficult to maintain and possibly require changes throughout the EasyAppointments codebase. 

To enable auto-detection for a new language, simply include its RFC subtag as a key-value pair in the [DEFAULT LANGUAGE](https://github.com/alextselegidis/easyappointments/blob/6b39b121b6712f2f490202bf00d0ae537b7497d3/src/application/config/config.php#L85) section of `src/application/config/config.php` , for example: 

```
'el' => 'greek',
```


