### PR TITLE
Fix language-switch control on legacy browsers.

### DIFF
--- a/src/assets/css/general.css
+++ b/src/assets/css/general.css
@@ -192,8 +192,11 @@ body .ui-datepicker .ui-datepicker-buttonpane button {
     vertical-align: middle;
 }
 
+li.language {
+	cursor: pointer;
+}
+
 li.language:hover {
-    cursor: pointer;
     color: #005580;
 }
 


### PR DESCRIPTION
Due to a known incompatibility between jQuery and older iOS browsers (e.g. iOS 10.3) the  language switch of the footer may fail to recognize tap/click events. This PR fixes the issue. In the absence of an old device, you may reproduce the bug and test the fix using the Xcode simulator.

