### PR TITLE
Fix appointment required fields validation

### DIFF
--- a/src/application/models/Customers_model.php
+++ b/src/application/models/Customers_model.php
@@ -68,7 +68,7 @@ class Customers_Model extends CI_Model {
      */
     public function exists($customer)
     {
-        if ( ! isset($customer['email']))
+        if (empty($customer['email']))
         {
             throw new Exception('Customer\'s email is not provided.');
         }
@@ -163,7 +163,7 @@ class Customers_Model extends CI_Model {
      */
     public function find_record_id($customer)
     {
-        if ( ! isset($customer['email']))
+        if (empty($customer['email']))
         {
             throw new Exception('Customer\'s email was not provided: '
                 . print_r($customer, TRUE));
@@ -212,9 +212,10 @@ class Customers_Model extends CI_Model {
             }
         }
         // Validate required fields
-        if ( ! isset($customer['last_name'])
-            || ! isset($customer['email'])
-            || ! isset($customer['phone_number']))
+        if (empty($customer['first_name'])
+            || empty($customer['last_name'])
+            || empty($customer['email'])
+            || empty($customer['phone_number']))
         {
             throw new Exception('Not all required fields are provided: '
                 . print_r($customer, TRUE));


### PR DESCRIPTION
We should be using empty to check the fields instead of isset. Otherwise,
appointments may be booked with empty fields if these are not properly validated
client-side for some reason, since they will be empty strings. Also, we should
check first_name.

(I made this patch a while ago, but I forgot to make a pull request for it!)