### PR TITLE
Identify customers through name and email

### DIFF
--- a/src/application/models/Customers_model.php
+++ b/src/application/models/Customers_model.php
@@ -68,7 +68,7 @@ class Customers_Model extends CI_Model {
      */
     public function exists($customer)
     {
-        if ( ! isset($customer['email']))
+        if (empty($customer['email']))
         {
             throw new Exception('Customer\'s email is not provided.');
         }
@@ -163,7 +163,7 @@ class Customers_Model extends CI_Model {
      */
     public function find_record_id($customer)
     {
-        if ( ! isset($customer['email']))
+        if (empty($customer['email']))
         {
             throw new Exception('Customer\'s email was not provided: '
                 . print_r($customer, TRUE));
@@ -212,9 +212,10 @@ class Customers_Model extends CI_Model {
             }
         }
         // Validate required fields
-        if ( ! isset($customer['last_name'])
-            || ! isset($customer['email'])
-            || ! isset($customer['phone_number']))
+        if (empty($customer['first_name'])
+            || empty($customer['last_name'])
+            || empty($customer['email'])
+            || empty($customer['phone_number']))
         {
             throw new Exception('Not all required fields are provided: '
                 . print_r($customer, TRUE));


### PR DESCRIPTION
Some people share an email address with other people. For example, spouses. Also, parents will often use their own email address when making appointments for their children. In these cases, EasyAppointments will clobber the existing name of the previous customer if someone else had previously made an appointment with that email address. This is a major issue, since it will also retroactively change the name for all previous appointments! This patch will identify customers by a combination of their name and email, so multiple people can share the same email address.