### PR TITLE
Add note to check spam folder after booking an appointment

### DIFF
--- a/src/application/language/english/translations_lang.php
+++ b/src/application/language/english/translations_lang.php
@@ -33,6 +33,7 @@ $lang['appointment_cancelled_title'] = 'Appointment Cancelled';
 $lang['reason'] = 'Reason';
 $lang['appointment_removed_from_schedule'] = 'The following appointment was removed from the company\'s schedule.';
 $lang['appointment_details_was_sent_to_you'] = 'An email with the appointment details has been sent to you.';
+$lang['check_spam_folder'] = 'Please check your spam folder if the email does not arrive within a few minutes.';
 $lang['add_to_google_calendar'] = 'Add to Google Calendar';
 $lang['appointment_booked'] = 'Your appointment has been successfully booked!';
 $lang['thank_you_for_appointment'] = 'Thank you for arranging an appointment with us. Below you can see the appointment details. Make changes by clicking the appointment link.';

--- a/src/application/views/appointments/book_success.php
+++ b/src/application/views/appointments/book_success.php
@@ -30,6 +30,7 @@
                         echo '
                             <h3>' . lang('appointment_registered') . '</h3>
                             <p>' . lang('appointment_details_was_sent_to_you') . '</p>
+                            <p><strong>' . lang('check_spam_folder') . '</strong></p>
                             <a href="' . site_url() . '" class="btn btn-success btn-large">
                                 <span class="glyphicon glyphicon-calendar"></span> ' .
                                 lang('go_to_booking_page') . '


### PR DESCRIPTION
Sometimes emails may go to spam, in which case it is helpful to remind customers that they should check their spam folders.