### PR TITLE
Change slot duration to 15 minutes

### DIFF
--- a/src/assets/js/backend_calendar_default_view.js
+++ b/src/assets/js/backend_calendar_default_view.js
@@ -1098,7 +1098,7 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
             height: _getCalendarHeight(),
             editable: true,
             firstDay: 0,
-            snapDuration: '00:30:00',
+            slotDuration: '00:15:00',
             timeFormat: timeFormat,
             slotLabelFormat: slotTimeFormat,
             allDayText: EALang.all_day,


### PR DESCRIPTION
Customers are able to book appointments in blocks of 15 minutes. This changes the calendar to be consistent with that. Drag-and-drop and dragging to create new appointments will snap to 15 minute increments.