### PR TITLE
Notifications are no more automatically hidden

### DIFF
--- a/src/assets/js/backend.js
+++ b/src/assets/js/backend.js
@@ -111,7 +111,7 @@ window.Backend = window.Backend || {};
         if (actions === undefined) {
             actions = [];
             setTimeout(function () {
-                $('#notification').fadeIn();
+                $('#notification').fadeOut();
             }, 5000);
         }
 


### PR DESCRIPTION
In [this commit](https://github.com/alextselegidis/easyappointments/commit/b8b66c28dae9f245eac3918b4f03c3c97178d75a#diff-b046c5e0db1ad3b0ac41e628ec59fbf4L113), `slideUp('slow')` is replaced by `fadeIn()`. This is a bug and because of that, notifications without actions are no more automatically hidden after 5 seconds.

We should use `fadeOut()`.