### PR TITLE
Remove delay before closing the appointments modale

### DIFF
--- a/src/assets/css/backend.css
+++ b/src/assets/css/backend.css
@@ -129,6 +129,19 @@ root {
     margin-right: 0 !important;
 }
 
+/* Alternative background-color for notification */
+#notification .alert.alert-danger {
+    background-color: #F5A8B6;
+    color: #F3F2EF;
+}
+#notification .alert.alert-danger .close {
+    color: #F3F2EF;
+}
+
+#notification .alert.alert-success {
+    background-color: #DCF5A8;
+}
+
 #loading {
     position: fixed;
     top: 0px;

--- a/src/assets/js/backend.js
+++ b/src/assets/js/backend.js
@@ -99,35 +99,44 @@ window.Backend = window.Backend || {};
      * Display backend notifications to user.
      *
      * Using this method you can display notifications to the use with custom messages. If the
-     * 'actions' array is provided then an action link will be displayed too.
+     * 'options.actions' array is provided then an action link will be displayed too.
      *
      * @param {String} message Notification message
-     * @param {Array} actions An array with custom actions that will be available to the user. Every
+     * @param {Object} options Nofitication options
+     * @param {Array} options.actions An array with custom actions that will be available to the user. Every
      * array item is an object that contains the 'label' and 'function' key values.
+     * @param {String} options.type The notification type ('danger' or 'success').
+     * @param {Number} options.duration The notification is automatically hidden after this time (default to 5000 ms).
      */
-    exports.displayNotification = function (message, actions) {
+    exports.displayNotification = function (message, options = {}) {
         message = message || 'NO MESSAGE PROVIDED FOR THIS NOTIFICATION';
 
-        if (actions === undefined) {
-            actions = [];
+        // Notifications are not automatically hidden when an action is provided
+        if (!options.actions) {
             setTimeout(function () {
-                $('#notification').fadeIn();
-            }, 5000);
+                $('#notification').fadeOut();
+            }, options.duration >= 0 ? options.duration : 5000);
         }
 
         var customActionsHtml = '';
+        if (options.actions) {
+            $.each(options.actions, function (index, action) {
+                var actionId = action.label.toLowerCase().replace(' ', '-');
+                customActionsHtml += '<button id="' + actionId + '" class="btn btn-default btn-xs">'
+                    + action.label + '</button>';
 
-        $.each(actions, function (index, action) {
-            var actionId = action.label.toLowerCase().replace(' ', '-');
-            customActionsHtml += '<button id="' + actionId + '" class="btn btn-default btn-xs">'
-                + action.label + '</button>';
+                $(document).off('click', '#' + actionId);
+                $(document).on('click', '#' + actionId, action.function);
+            });
+        }
 
-            $(document).off('click', '#' + actionId);
-            $(document).on('click', '#' + actionId, action.function);
-        });
+        var classType = '';
+        if (options.type) {
+            classType += ' alert-' + options.type
+        }
 
         var notificationHtml =
-            '<div class="notification alert">' +
+            '<div class="notification alert' + classType + '">' +
             '<button type="button" class="close" data-dismiss="alert" aria-label="Close">' +
             '<span aria-hidden="true">&times;</span>' +
             '</button>' +

--- a/src/assets/js/backend_calendar_appointments_modal.js
+++ b/src/assets/js/backend_calendar_appointments_modal.js
@@ -93,16 +93,12 @@ window.BackendCalendarAppointmentsModal = window.BackendCalendarAppointmentsModa
                 }
 
                 // Display success message to the user.
-                $dialog.find('.modal-message').text(EALang.appointment_saved);
-                $dialog.find('.modal-message').addClass('alert-success').removeClass('alert-danger hidden');
-                $dialog.find('.modal-body').scrollTop(0);
+                Backend.displayNotification(EALang.appointment_saved);
 
-                // Close the modal dialog and refresh the calendar appointments after one second.
-                setTimeout(function () {
-                    $dialog.find('.alert').addClass('hidden');
-                    $dialog.modal('hide');
-                    $('#select-filter-item').trigger('change');
-                }, 2000);
+                // Close the modal dialog and refresh the calendar appointments.
+                $dialog.find('.alert').addClass('hidden');
+                $dialog.modal('hide');
+                $('#select-filter-item').trigger('change');
             };
 
             // Define error callback.

--- a/src/assets/js/backend_calendar_appointments_modal.js
+++ b/src/assets/js/backend_calendar_appointments_modal.js
@@ -93,7 +93,7 @@ window.BackendCalendarAppointmentsModal = window.BackendCalendarAppointmentsModa
                 }
 
                 // Display success message to the user.
-                Backend.displayNotification(EALang.appointment_saved);
+                Backend.displayNotification(EALang.appointment_saved, { type: 'success' });
 
                 // Close the modal dialog and refresh the calendar appointments.
                 $dialog.find('.alert').addClass('hidden');

--- a/src/assets/js/backend_calendar_default_view.js
+++ b/src/assets/js/backend_calendar_default_view.js
@@ -434,12 +434,12 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                     }, 'json').fail(GeneralFunctions.ajaxFailureHandler);
                 };
 
-                Backend.displayNotification(EALang.appointment_updated, [
+                Backend.displayNotification(EALang.appointment_updated, { actions: [
                     {
                         'label': 'Undo',
                         'function': undoFunction
                     }
-                ]);
+                ]});
                 $('#footer').css('position', 'static'); // Footer position fix.
 
                 // Update the event data for later use.
@@ -494,12 +494,12 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                     }, 'json').fail(GeneralFunctions.ajaxFailureHandler);
                 };
 
-                Backend.displayNotification(EALang.unavailable_updated, [
+                Backend.displayNotification(EALang.unavailable_updated, { actions: [
                     {
                         'label': 'Undo',
                         'function': undoFunction
                     }
-                ]);
+                ]});
 
                 $('#footer').css('position', 'static'); // Footer position fix.
 
@@ -618,12 +618,12 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                     }, 'json').fail(GeneralFunctions.ajaxFailureHandler);
                 };
 
-                Backend.displayNotification(EALang.appointment_updated, [
+                Backend.displayNotification(EALang.appointment_updated, { actions: [
                     {
                         'label': 'Undo',
                         'function': undoFunction
                     }
-                ]);
+                ]});
 
                 $('#footer').css('position', 'static'); // Footer position fix.
             };
@@ -679,12 +679,12 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                     }, 'json').fail(GeneralFunctions.ajaxFailureHandler);
                 };
 
-                Backend.displayNotification(EALang.unavailable_updated, [
+                Backend.displayNotification(EALang.unavailable_updated, { actions: [
                     {
                         label: 'Undo',
                         function: undoFunction
                     }
-                ]);
+                ]});
 
                 $('#footer').css('position', 'static'); // Footer position fix.
             };

--- a/src/assets/js/backend_calendar_unavailabilities_modal.js
+++ b/src/assets/js/backend_calendar_unavailabilities_modal.js
@@ -81,7 +81,7 @@ window.BackendCalendarUnavailabilitiesModal = window.BackendCalendarUnavailabili
                 }
 
                 // Display success message to the user.
-                Backend.displayNotification(EALang.unavailable_saved);
+                Backend.displayNotification(EALang.unavailable_saved, { type: 'success' });
 
                 // Close the modal dialog and refresh the calendar appointments.
                 $dialog.find('.alert').addClass('hidden');

--- a/src/assets/js/backend_calendar_unavailabilities_modal.js
+++ b/src/assets/js/backend_calendar_unavailabilities_modal.js
@@ -81,17 +81,12 @@ window.BackendCalendarUnavailabilitiesModal = window.BackendCalendarUnavailabili
                 }
 
                 // Display success message to the user.
-                $dialog.find('.modal-message')
-                    .text(EALang.unavailable_saved)
-                    .addClass('alert-success')
-                    .removeClass('alert-danger hidden');
+                Backend.displayNotification(EALang.unavailable_saved);
 
-                // Close the modal dialog and refresh the calendar appointments after one second.
-                setTimeout(function () {
-                    $dialog.find('.alert').addClass('hidden');
-                    $dialog.modal('hide');
-                    $('#select-filter-item').trigger('change');
-                }, 2000);
+                // Close the modal dialog and refresh the calendar appointments.
+                $dialog.find('.alert').addClass('hidden');
+                $dialog.modal('hide');
+                $('#select-filter-item').trigger('change');
             };
 
             var errorCallback = function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
I think that the 2 seconds timeout before closing the appointment modal (backend appointment creation) on success is not very user friendly. The user could think that the action is not completed and should wait for nothing.

I think that this timeout was here only to allow the user to view the success notification in the modal before closing it ?

If so, to resolve this, I've move this success notification to the left right window corner of the calendar view (in the same place of the undo notification).