### PR TITLE
[Bug] Notifications are no longer automatically hidden

### DIFF
--- a/assets/js/backend.js
+++ b/assets/js/backend.js
@@ -114,7 +114,7 @@ window.Backend = window.Backend || {};
             actions = [];
 
             setTimeout(function () {
-                $notification.fadeIn();
+                $notification.fadeOut();
             }, 5000);
         }
 


### PR DESCRIPTION
In commit b8b66c28dae9f245eac3918b4f03c3c97178d75a, `slideUp('slow')` is replaced by `fadeIn()`. This is a bug and because of that, notifications without actions are no more automatically hidden after 5 seconds.

`fadeOut()` should be used instead.