### PR TITLE
Remove delay before closing the appointments modale

### DIFF
--- a/assets/js/backend_calendar_appointments_modal.js
+++ b/assets/js/backend_calendar_appointments_modal.js
@@ -99,16 +99,12 @@ window.BackendCalendarAppointmentsModal = window.BackendCalendarAppointmentsModa
             // Define success callback.
             var successCallback = function (response) {
                 // Display success message to the user.
-                $dialog.find('.modal-message').text(EALang.appointment_saved);
-                $dialog.find('.modal-message').addClass('alert-success').removeClass('alert-danger hidden');
-                $dialog.find('.modal-body').scrollTop(0);
+                Backend.displayNotification(EALang.appointment_saved);
 
-                // Close the modal dialog and refresh the calendar appointments after one second.
-                setTimeout(function () {
-                    $dialog.find('.alert').addClass('hidden');
-                    $dialog.modal('hide');
-                    $('#select-filter-item').trigger('change');
-                }, 2000);
+                // Close the modal dialog and refresh the calendar appointments.
+                $dialog.find('.alert').addClass('hidden');
+                $dialog.modal('hide');
+                $('#select-filter-item').trigger('change');
             };
 
             // Define error callback.

--- a/assets/js/backend_calendar_unavailabilities_modal.js
+++ b/assets/js/backend_calendar_unavailabilities_modal.js
@@ -60,17 +60,12 @@ window.BackendCalendarUnavailabilitiesModal = window.BackendCalendarUnavailabili
 
             var successCallback = function (response) {
                 // Display success message to the user.
-                $dialog.find('.modal-message')
-                    .text(EALang.unavailable_saved)
-                    .addClass('alert-success')
-                    .removeClass('alert-danger hidden');
+                Backend.displayNotification(EALang.unavailable_saved);
 
-                // Close the modal dialog and refresh the calendar appointments after one second.
-                setTimeout(function () {
-                    $dialog.find('.alert').addClass('hidden');
-                    $dialog.modal('hide');
-                    $('#select-filter-item').trigger('change');
-                }, 2000);
+                // Close the modal dialog and refresh the calendar appointments.
+                $dialog.find('.alert').addClass('hidden');
+                $dialog.modal('hide');
+                $('#select-filter-item').trigger('change');
             };
 
             var errorCallback = function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
I think that the 2 seconds timeout before closing the appointment modal (backend appointment creation) on success is not very user friendly. The user could think that the action is not completed and should wait for nothing.

I think that this timeout was here only to allow the user to view the success notification in the modal before closing it ?

If so, to resolve this, I've move the success notification to the left right window corner of the calendar view (in the same place of the undo notification).