### PR TITLE
Prevent click events on the backend calendar

### DIFF
--- a/assets/js/backend_calendar_default_view.js
+++ b/assets/js/backend_calendar_default_view.js
@@ -1183,6 +1183,7 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
             // Selectable
             selectable: true,
             selectHelper: true,
+            selectMinDistance: 5, // To prevent opening the new appointment modal when clicking on the calendar
             select: function (start, end, jsEvent, view) {
                 if (!start.hasTime() || !end.hasTime()) {
                     return;

--- a/assets/js/backend_calendar_table_view.js
+++ b/assets/js/backend_calendar_table_view.js
@@ -653,6 +653,7 @@ window.BackendCalendarTableView = window.BackendCalendarTableView || {};
             // Selectable
             selectable: true,
             selectHelper: true,
+            selectMinDistance: 5, // To prevent opening the new appointment modal when clicking on the calendar
             select: function (start, end, jsEvent, view) {
                 if (!start.hasTime() || !end.hasTime()) {
                     return;


### PR DESCRIPTION
Fix #771

Prevent opening the new appointment modal on simple clicking on the backend calendar. The user should now click and move the pointer to trig the new appointment action.