### PR TITLE
Close opened popovers when new appointment modal is displayed

### DIFF
--- a/assets/js/backend_calendar_default_view.js
+++ b/assets/js/backend_calendar_default_view.js
@@ -1188,6 +1188,9 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
                     return;
                 }
 
+                // Close all open popovers
+                $('.popover').remove();
+
                 $('#insert-appointment').trigger('click');
 
                 // Preselect service & provider.

--- a/assets/js/backend_calendar_table_view.js
+++ b/assets/js/backend_calendar_table_view.js
@@ -658,6 +658,9 @@ window.BackendCalendarTableView = window.BackendCalendarTableView || {};
                     return;
                 }
 
+                // Close all open popovers
+                $('.popover').remove();
+
                 $('#insert-appointment').trigger('click');
 
                 // Preselect service & provider.


### PR DESCRIPTION
I think that this is better to close appointment popover when the new appointment action is trigged and that the new appointment modal is displayed. Closing this popover is a good idea to not overload the calendar.