### PR TITLE
Fix display of date-pickers used on appointments create/update modals

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -80,7 +80,6 @@ body .ui-widget.ui-widget-content {
 
 body #ui-datepicker-div {
     margin-top: 4px;
-    z-index: 4 !important;
 }
 
 body .ui-datepicker .ui-widget-header {


### PR DESCRIPTION
Fix #757

This is due to [this change](https://github.com/alextselegidis/easyappointments/commit/080488aa7db1c76317ba08e1fa96ebf94274a749#diff-10eecd199403e50999776a7344b873edR83). But I've not found the reason of this change.. Is it really needed ?