### PR TITLE
Fix disabled bug with insert dropdown in backend.

### DIFF
--- a/application/views/backend/calendar.php
+++ b/application/views/backend/calendar.php
@@ -73,7 +73,7 @@
                         <span class="glyphicon glyphicon-plus"></span>
                         <?= lang('appointment') ?>
                     </button>
-                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    <button type="button" id="insert-dropdown" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                         <span class="caret"></span>
                         <span class="sr-only">Toggle Dropdown</span>
                     </button>

--- a/assets/js/backend_calendar_default_view.js
+++ b/assets/js/backend_calendar_default_view.js
@@ -224,11 +224,11 @@ window.BackendCalendarDefaultView = window.BackendCalendarDefaultView || {};
         $('#select-filter-item').change(function () {
             // If current value is service, then the sync buttons must be disabled.
             if ($('#select-filter-item option:selected').attr('type') === FILTER_TYPE_SERVICE) {
-                $('#google-sync, #enable-sync, #insert-appointment, #insert-unavailable').prop('disabled', true);
+                $('#google-sync, #enable-sync, #insert-appointment, #insert-dropdown').prop('disabled', true);
                 $('#calendar').fullCalendar('option', 'selectable', false);
                 $('#calendar').fullCalendar('option', 'editable', false);
             } else {
-                $('#google-sync, #enable-sync, #insert-appointment, #insert-unavailable').prop('disabled', false);
+                $('#google-sync, #enable-sync, #insert-appointment, #insert-dropdown').prop('disabled', false);
                 $('#calendar').fullCalendar('option', 'selectable', true);
                 $('#calendar').fullCalendar('option', 'editable', true);
 


### PR DESCRIPTION
When a service is displayed in the backend calendar, the insert-unavailable and insert-extra-period buttons were not correctly disabled.