### PR TITLE
Fix: appointment hash lost when backend/index route required the user to log in

### DIFF
--- a/application/controllers/Backend.php
+++ b/application/controllers/Backend.php
@@ -73,7 +73,9 @@ class Backend extends CI_Controller {
      */
     public function index($appointment_hash = '')
     {
-        $this->session->set_userdata('dest_url', site_url('backend'));
+        $siteUrl = $appointment_hash ? ('backend/index/' . $appointment_hash) : 'backend';
+
+        $this->session->set_userdata('dest_url', site_url($siteUrl));
 
         if ( ! $this->has_privileges(PRIV_APPOINTMENTS))
         {


### PR DESCRIPTION
Fix a bug where a query to `backend/` with an `$appointments_hash` parameter was not correctly redirected if the user has to log in.