### PR TITLE
Fix: reset has-error class on resetForm() function.

### DIFF
--- a/assets/js/backend_categories_helper.js
+++ b/assets/js/backend_categories_helper.js
@@ -309,6 +309,8 @@
         $('#categories .record-details').find('input, textarea').prop('readonly', true);
         $('#edit-category, #delete-category').prop('disabled', true);
 
+        $('.record-details .has-error').removeClass('has-error');
+
         $('#filter-categories .selected').removeClass('selected');
         $('#filter-categories .results').css('color', '');
         $('#filter-categories button').prop('disabled', false);

--- a/assets/js/backend_services_helper.js
+++ b/assets/js/backend_services_helper.js
@@ -277,6 +277,8 @@
         $('#services .record-details').find('input, textarea').prop('readonly', true);
         $('#services .record-details').find('select').prop('disabled', true);
 
+        $('.record-details .has-error').removeClass('has-error');
+
         $('#filter-services .selected').removeClass('selected');
         $('#filter-services button').prop('disabled', false);
         $('#filter-services .results').css('color', '');

--- a/assets/js/backend_users_admins.js
+++ b/assets/js/backend_users_admins.js
@@ -300,6 +300,8 @@
         $('#admin-notifications').removeClass('active');
         $('#edit-admin, #delete-admin').prop('disabled', true);
 
+        $('#admins .has-error').removeClass('has-error');
+
         $('#filter-admins .selected').removeClass('selected');
         $('#filter-admins button').prop('disabled', false);
         $('#filter-admins .results').css('color', '');

--- a/assets/js/backend_users_providers.js
+++ b/assets/js/backend_users_providers.js
@@ -360,6 +360,8 @@
         $('.breaks').find('.edit-break, .delete-break').prop('disabled', true);
         $('.extra-periods').find('.edit-extra, .delete-extra').prop('disabled', true);
 
+        $('#providers .has-error').removeClass('has-error');
+
         $('#edit-provider, #delete-provider').prop('disabled', true);
         $('#providers .record-details').find('input, textarea').val('');
         $('#provider-services input:checkbox').prop('checked', false);


### PR DESCRIPTION
On some form (client, service, etc.), the `resetForm()` function does not remove `.has-error` class from fields.

To reproduce, go to the services form, click on the "add a new service" button, click on the "save service" button. The required fields are now red with the `.has-error` class. Now click on the "cancel" button and this fields stay red !