### PR TITLE
Remove timezone_model fix email notifications

### DIFF
--- a/engine/Notifications/Email.php
+++ b/engine/Notifications/Email.php
@@ -87,9 +87,7 @@ class Email {
     ) {
         $framework = get_instance();
 
-        $framework->load->model('timezones_model');
-
-        $timezones = $framework->timezones_model->to_array();
+        $timezones = $framework->timezones->to_array();
 
         switch ($company['date_format'])
         {
@@ -182,9 +180,8 @@ class Email {
     ) {
         $framework = get_instance();
 
-        $framework->load->model('timezones_model');
 
-        $timezones = $framework->timezones_model->to_array();
+        $timezones = $framework->timezones->to_array();
 
         switch ($company['date_format'])
         {


### PR DESCRIPTION
Emails weren't being sent due to an error which the notifications engine was trying to load Timezone_model but in the develop branch it is already loaded by the framework and was giving off an error which made all notifications fail.