### PR TITLE
Fix events with no start

### DIFF
--- a/src/application/controllers/Google.php
+++ b/src/application/controllers/Google.php
@@ -219,7 +219,7 @@ class Google extends CI_Controller {
             foreach ($events->getItems() as $event)
             {
                 $results = $this->appointments_model->get_batch(['id_google_calendar' => $event->getId()]);
-                if (count($results) == 0)
+                if (count($results) == 0 && $event->start && $event->end)
                 {
                     // Record doesn't exist in E!A, so add the event now.
                     $appointment = [


### PR DESCRIPTION
There are some events with no start date. Sounds weird but I've found some.
It fails and breaks the sync process, so with this check it will continue and skip those events.
TODO: what should be done with this weird events? I think that they are Google failure as they have no summary, notes, etc..

```php
Google_Event Object
(
    [__creatorType:protected] => Google_EventCreator
    [__creatorDataType:protected] => 
    [creator] => 
    [__organizerType:protected] => Google_EventOrganizer
    [__organizerDataType:protected] => 
    [organizer] => 
    [summary] => 
    [id] => xxxxxxxx
    [__attendeesType:protected] => Google_EventAttendee
    [__attendeesDataType:protected] => array
    [attendees] => 
    [htmlLink] => 
    [recurrence] => 
    [__startType:protected] => Google_EventDateTime
    [__startDataType:protected] => 
    [start] => 
    [etag] => "xxxxxxx"
    [location] => 
    [recurringEventId] => xxxxxxxx
    [__gadgetType:protected] => Google_EventGadget
    [__gadgetDataType:protected] => 
    [gadget] => 
    [status] => cancelled
    [updated] => 
    [description] => 
    [iCalUID] => 
    [__extendedPropertiesType:protected] => Google_EventExtendedProperties
    [__extendedPropertiesDataType:protected] => 
    [extendedProperties] => 
    [endTimeUnspecified] => 
    [sequence] => 
    [visibility] => 
    [guestsCanModify] => 
    [__endType:protected] => Google_EventDateTime
    [__endDataType:protected] => 
    [end] => 
    [attendeesOmitted] => 
    [kind] => calendar#event
    [locked] => 
    [created] => 
    [colorId] => 
    [anyoneCanAddSelf] => 
    [__remindersType:protected] => Google_EventReminders
    [__remindersDataType:protected] => 
    [reminders] => 
    [guestsCanSeeOtherGuests] => 
    [__originalStartTimeType:protected] => Google_EventDateTime
    [__originalStartTimeDataType:protected] => 
    [originalStartTime] => Google_EventDateTime Object
        (
            [date] => 
            [timeZone] => UTC
            [dateTime] => 2020-08-07T16:30:00+02:00
        )

    [guestsCanInviteOthers] => 
    [transparency] => 
    [privateCopy] => 
)
```