### PR TITLE
Retrive unavailability that are longer days

### DIFF
--- a/src/application/controllers/Appointments.php
+++ b/src/application/controllers/Appointments.php
@@ -1121,7 +1121,8 @@ class Appointments extends CI_Controller {
 
         $unavailabilities = $this->appointments_model->get_batch([
             'is_unavailable' => TRUE,
-            'DATE(start_datetime)' => $selected_date,
+            'DATE(start_datetime) <=' => $selected_date,
+            'DATE(end_datetime) >=' => $selected_date,
             'id_users_provider' => $provider['id']
         ]);
 


### PR DESCRIPTION
## Issue
If you have a Provider that has an unavailable period longer than 1 day with the start date in the past months it isn't taken by the system and the provider result available

## Steps to reproduce the issues
* Create a Service that has more than 1 attendants that has only 1 Provider
* Create an Unavailable period for the User that starts in the month before today and end in the middle of the current month
