### PR TITLE
Remove extra nested property when creating a Provider via API.

### DIFF
--- a/application/controllers/api/v1/Providers.php
+++ b/application/controllers/api/v1/Providers.php
@@ -102,7 +102,7 @@ class Providers extends API_V1_Controller {
                 throw new Exception('No settings property provided.');
             }
 
-            if ( ! array_key_exists('working_plan', $provider['settings']['working_plan']))
+            if ( ! array_key_exists('working_plan', $provider['settings']))
             {
                 $provider['settings']['working_plan'] = $this->settings_model->get_setting('company_working_plan');
             }


### PR DESCRIPTION
Hopefully this is actually a bug and not me misunderstanding something.