### PR TITLE
Backend calendar table events missing or duplicated

### DIFF
--- a/application/controllers/Backend_api.php
+++ b/application/controllers/Backend_api.php
@@ -88,6 +88,7 @@ class Backend_api extends EA_Controller {
                 $appointment['service'] = $this->services_model->get_row($appointment['id_services']);
                 $appointment['customer'] = $this->customers_model->get_row($appointment['id_users_customer']);
             }
+            unset ($appointment);
 
             $user_id = $this->session->userdata('user_id');
             $role_slug = $this->session->userdata('role_slug');


### PR DESCRIPTION
Hi, am not an PHP expert and this is my first PR .. but I had an issue with calendar appointments in the table view when logged in as secretary, there would events appointments be missing or duplicated.

I found this occurs when you use a reference in a foreach loop and reuse that variable in a successive foreach. This was recently implemented when filtering appointments depending on the logged in role.

See https://stackoverflow.com/questions/3307409/php-pass-by-reference-in-foreach
or https://www.php.net/manual/en/control-structures.foreach.php


Thank you for your time and this tool and best regards