### PR TITLE
[1038] Sender and return address set to pass spamfilters

### DIFF
--- a/engine/Notifications/Email.php
+++ b/engine/Notifications/Email.php
@@ -321,6 +321,8 @@ class Email {
             $mailer->Password = $this->config['smtp_pass'];
             $mailer->SMTPSecure = $this->config['smtp_crypto'];
             $mailer->Port = $this->config['smtp_port'];
+            $mailer->Sender = $settings['company_email'];
+            $mailer->SetFrom($settings['company_email'], $settings['company_name'], FALSE); 
         }
 
         $mailer->IsHTML($this->config['mailtype'] === 'html');


### PR DESCRIPTION
As per issue #1038, I implemented a fix to allow emails to pass spam filters (as long as DMARC is setup correctly).