### PR TITLE
fix reload of backend calendar table - use startof day for column

### DIFF
--- a/assets/js/backend_calendar_table_view.js
+++ b/assets/js/backend_calendar_table_view.js
@@ -1717,10 +1717,10 @@ window.BackendCalendarTableView = window.BackendCalendarTableView || {};
     exports.initialize = function () {
         createHeader();
 
-        var startDate = moment().toDate();
-        var endDate = moment().add(Number($('#select-filter-item').val()) - 1, 'days').toDate();
+        var startDate = moment().startOf('day');
+        var endDate = startDate.clone().add(Number($('#select-filter-item').val()) - 1, 'days');
 
-        createView(startDate, endDate);
+        createView(startDate.toDate(), endDate.toDate());
 
         $('#insert-working-plan-exception').hide();
 


### PR DESCRIPTION
Hi,

my installation is heavily relying on the table view of the backend calendar.
I found that events and the view would'n reload when hitting the reload button under certain circumstances. Initially when reloading the page, the reload button is not functional but it becomes working once I navigate back and forth through the days. I figured out, that the reload function compares dates when cycling through the columns, and during the initialization, the column date includes the time while in every other instance, only the yy/mm/dd portion of a moment is used.

moment().startOf('day');
fixes it for me, but I'm not experienced enough to tell if this is the best solution.

Thanks