### PR TITLE
FIX Providers API incorrect `array_key_exists`

### DIFF
--- a/application/controllers/api/v1/Providers.php
+++ b/application/controllers/api/v1/Providers.php
@@ -102,7 +102,7 @@ class Providers extends API_V1_Controller {
                 throw new Exception('No settings property provided.');
             }
 
-            if ( ! array_key_exists('working_plan', $provider['settings']['working_plan']))
+            if ( ! array_key_exists('working_plan', $provider['settings']))
             {
                 $provider['settings']['working_plan'] = $this->settings_model->get_setting('company_working_plan');
             }


### PR DESCRIPTION
- `array_key_exists` should search for they key `working_plan` within `$provider['settings']` and not `$provider['settings']['working_plan']`