### PR TITLE
Retain linebreaks in the service description

### DIFF
--- a/application/views/backend/services.php
+++ b/application/views/backend/services.php
@@ -175,7 +175,7 @@
 
                     <div class="form-group">
                         <label for="service-description">
-                            <?= lang('description') ?>
+                            <?= nl2br(lang('description')) ?>
                         </label>
                         <textarea id="service-description" rows="4" class="form-control"></textarea>
                     </div>


### PR DESCRIPTION
Our org uses EasyAppointments (I'm not an admin, just a org-side user) and would like to add extensive descriptions with enumerations etc. in the service description, however these don't seem to be retained from the input text to the display text (that a user sees). 

From my limited knowledge regarding php/html and a bit of research, I think adding nl2br to line 178 would do the trick, but I'm not sure.
Greatly appreciate input on this!