### PR TITLE
Update Calendar.php

### DIFF
--- a/application/controllers/Calendar.php
+++ b/application/controllers/Calendar.php
@@ -560,6 +560,13 @@ class Calendar extends EA_Controller {
                     }
                 }
             }
+            
+            // arrays need to be re-indexed after items have been unset
+            $response_appointments = array_values($response['appointments']);
+            $unavailability_events = array_values($response['unavailability_events']);
+
+            $response['appointments'] = $response_appointments;
+            $response['unavailability_events'] = $unavailability_events;
 
             json_response($response);
         }


### PR DESCRIPTION
Appointments and unavailabilities arrays need to be reindexed after something has been removed. If not, table view breaks for providers /secretaries if something has been unset, at least for me :)

Ported from [#1188](https://github.com/alextselegidis/easyappointments/pull/1188)- untested on develop branch :)