### PR TITLE
Better content type header parsing

### DIFF
--- a/application/core/EA_Input.php
+++ b/application/core/EA_Input.php
@@ -55,7 +55,7 @@ class EA_Input extends CI_Input {
         /** @var EA_Controller $CI */
         $CI = &get_instance();
 
-        if ($CI->input->get_request_header('Content-Type') !== 'application/json')
+        if (strpos($CI->input->get_request_header('Content-Type'), 'application/json') === false)
         {
             return NULL;
         }


### PR DESCRIPTION
hey,

the current API calls fails when a rest client calls the api endpoints with the `Content-Type: application/json; charset=UTF8` header.

This is due to this exact matching in the `EA_Input.php`  where the header value must be exactly `application/json`. 

 `Content-Type: application/json; charset=UTF8` being a valid content type, I believe EA should check more loosely for the `application/json` string