### PR TITLE
API endpoint for available dates

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -132,6 +132,8 @@ $route['api/v1/settings/(:any)']['put'] = 'api/v1/settings_api_v1/update/$1';
 
 $route['api/v1/availabilities']['get'] = 'api/v1/availabilities_api_v1/get';
 
+$route['api/v1/availabilities/dates']['get'] = 'api/v1/availabilities_api_v1/dates';
+
 /*
 | -------------------------------------------------------------------------
 | CUSTOM ROUTING

--- a/application/controllers/api/v1/Availabilities_api_v1.php
+++ b/application/controllers/api/v1/Availabilities_api_v1.php
@@ -77,4 +77,55 @@ class Availabilities_api_v1 extends EA_Controller {
             json_exception($e);
         }
     }
+
+    /**
+     * Generate the available dates based on the selected month, service and provider.
+     *
+     * This resource requires the following query parameters:
+     *
+     *   - serviceId
+     *   - providerId
+     *   - month
+     *
+     * If no month parameter is provided then the current month will be used.
+     */
+    public function dates()
+    {
+        try
+        {
+            $provider_id = request('providerId');
+
+            $service_id = request('serviceId');
+
+            $month = request('month');
+            $month = new DateTime($month);
+
+            $provider = $this->providers_model->find($provider_id);
+
+            $service = $this->services_model->find($service_id);
+
+            $number_of_days_in_month = (int)$month->format('t');
+            $available_dates = [];
+
+            for ($i = 1; $i <= $number_of_days_in_month; $i++)
+            {
+                $current_date = new DateTime($month->format('Y-m') . '-' . $i);
+
+                $available_hours = $this->availability->get_available_hours(
+                    $current_date->format('Y-m-d'),
+                    $service,
+                    $provider
+                );
+
+                if ( !empty($available_hours) )
+                    $available_dates[] = $current_date->format('Y-m-d');
+            }
+
+            json_response($available_dates);
+        }
+        catch (Throwable $e)
+        {
+            json_exception($e);
+        }
+    }
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -65,6 +65,44 @@ paths:
       security:
         - BearerToken: [ ]
         - BasicAuth: [ ]
+  /availabilities/dates:
+    get:
+      tags:
+        - availabilities
+      summary: Gets availability dates
+      parameters:
+        - name: providerId
+          in: query
+          schema:
+            type: integer
+          required: true
+        - name: serviceId
+          in: query
+          schema:
+            type: integer
+          required: true
+        - name: month
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailabilityDates'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - BearerToken: [ ]
+        - BasicAuth: [ ]
   /appointments:
     get:
       tags:
@@ -1719,6 +1757,10 @@ paths:
 components:
   schemas:
     Availabilities:
+      type: array
+      items:
+        type: string
+    AvailabilityDates:
       type: array
       items:
         type: string


### PR DESCRIPTION
An endpoint that returns all dates with availabilities for a certain month.

`/availabilities/dates?month=2022-07&providerId=xx&serviceId=xx`

Returns:
```js
["2022-07-05", "2022-07-14", "2022-07-22"]
```
See #1282 