### PR TITLE
Add unavailabilities from google calendar

### DIFF
--- a/application/controllers/Google.php
+++ b/application/controllers/Google.php
@@ -219,13 +219,6 @@ class Google extends EA_Controller {
                 $event_end = new DateTime($google_event->getEnd()->getDateTime());
                 $event_end->setTimezone($provider_timezone);
 
-                $results = $CI->appointments_model->get(['id_google_calendar' => $google_event->getId()]);
-
-                if ( ! empty($results))
-                {
-                    continue;
-                }
-
                 // Record doesn't exist in the Easy!Appointments, so add the event now.
                 $appointment = [
                     'start_datetime' => $event_start->format('Y-m-d H:i:s'),
@@ -239,7 +232,16 @@ class Google extends EA_Controller {
                     'id_services' => NULL,
                 ];
 
-                $CI->appointments_model->save($appointment);
+                //Get Appointment ID by google calendar API Token
+                $results = $CI->appointments_model->get(['id_google_calendar' => $google_event->getId()], NULL, NULL, NULL, FALSE, TRUE);
+
+                if ( ! empty($results))
+                {
+                    //if the Appointment id was found add the ID to the appointment array so it can update it instead to insert a new one
+                    $appointment["id"]=$results[0]["id"];
+                }
+
+                $CI->appointments_model->save($appointment, TRUE);
             }
 
             json_response([


### PR DESCRIPTION
Add Capability to recieve Events added from Google Calendar as Unavailability

How to test:

New Event
1. Syncronize Provider with google calendar
2. Add an event on the syncronized calendar
3. Start Sync on EasyAppointments
4. The event will be added in EasyAppointments as an Unavailability
5. The event can bi edited and moved in both (google calendar or EasyAppointments) and at the next sync will be updated correctly

-----
Notes: This fix does'nt add delete sync feature so:

1. If inserted event (unavailability recieved from google calendar) is deleted from Google Calendar (and not from EasyAppointments) it will remain in EasyAppointmens with no further sync to google (because the gogole token is already set on the event)
2. If event is deleted from EasyAppointments and not in Google calendar the event will be syncronized again to EasyAppointments on next sync

We are also studyiing how to ad a better delete sync feature. When it will be ready we will send another pull request.
Thanks