### PR TITLE
Adding a mail capture server.

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,6 @@
+# Port for mail capture server
+MAIL_PORT=8001
+# Port to access to database
+DATABASE_PORT=3306
+# Port to access php server.
+SERVER_PORT=8000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,21 +1,31 @@
 version: "3.1"
 services:
+    mail:
+        image: mailhog/mailhog:latest
+        container_name: easyappointments-mail
+        ports:
+            - "${MAIL_PORT:-8025}:8025"
+
     mysql:
         image: mysql:5.7
         container_name: easyappointments-database
         volumes:
-            - ./mysql:/var/lib/mysql
+            - easyappointments-database-volume:/var/lib/mysql
         environment:
             - MYSQL_ROOT_PASSWORD=root
             - MYSQL_DATABASE=easyappointments
         ports:
-            - "8001:3306"
+            - "${DATABASE_PORT:-8001}:3306"
+
     server:
         build: ./server
         image: easyappointments-server:v1
         container_name: easyappointments-server
         ports:
-            - "8000:80"
+            - "${SERVER_PORT:-8000}:80"
         volumes:
             - ../:/var/www/html
             - ./server/php.ini:/usr/local/etc/php/conf.d/99-overrides.ini
+
+volumes:
+  easyappointments-database-volume:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -8,8 +8,17 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        ssmtp \
+        mailutils \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j$(nproc) gd gettext mysqli pdo_mysql
+
+RUN echo "hostname=localhost.localdomain" > /etc/ssmtp/ssmtp.conf
+RUN echo "root=root@localhost.localdomain" >> /etc/ssmtp/ssmtp.conf
+RUN echo "mailhub=mail:1025" >> /etc/ssmtp/ssmtp.conf
+RUN echo "sendmail_path=sendmail -i -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini
+RUN echo "localhost localhost.localdomain" >> /etc/hosts
 
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,7 +39,7 @@ class Config {
 }
 ```
 
-In the host machine the server is accessible from `http://localhost:8000` and the database from `localhost:8001`.  
+In the host machine the server is accessible from `http://localhost:8000`,  email testing tool from `http://localhost:8025` and the database from `localhost:8001`. Ports can be configured creating an `.env` file in `/docker` folder. See `.env.example` for more information. 
 
 You can remove the docker containers with `docker rm easyappointments-server easyappointments-database`. 
 


### PR DESCRIPTION
Add the MailHog email testing tool to docker compose to enhance the development and testing experience of application-generated mail by capturing all emails sent by the application.

List of emails:

<img width="1044" alt="Screenshot 2022-09-26 at 09 25 11" src="https://user-images.githubusercontent.com/3626656/192218678-52118c68-5a3d-456b-a519-d29254fcb2e3.png">

Email details:

<img width="1043" alt="Screenshot 2022-09-26 at 09 24 44" src="https://user-images.githubusercontent.com/3626656/192218849-3b33417c-d24e-4de4-bdf4-7abd5860e81f.png">

