### PR TITLE
fix: warning on providers API result when no working plans exceptions is set

### DIFF
--- a/engine/Api/V1/Parsers/Providers.php
+++ b/engine/Api/V1/Parsers/Providers.php
@@ -73,7 +73,7 @@ class Providers implements ParsersInterface {
                     ? json_decode($response['settings']['working_plan'], TRUE)
                     : NULL,
                 'workingPlanExceptions' => array_key_exists('working_plan_exceptions', $response['settings'])
-                    ? json_decode($response['settings']['working_plan_exceptions'], TRUE)
+                    ? json_decode($response['settings']['working_plan_exceptions'] ?? '', TRUE)
                     : NULL,
             ];
         }


### PR DESCRIPTION
Avoid Warnings that you see on this screenshot : https://snipboard.io/kX1KTS.jpg