### PR TITLE
Fixes for frontend problems running in release mode

### DIFF
--- a/application/controllers/Calendar.php
+++ b/application/controllers/Calendar.php
@@ -129,7 +129,7 @@ class Calendar extends EA_Controller {
             'timezones' => $this->timezones->to_array(),
             'privileges' => $privileges,
             'calendar_view' => $calendar_view,
-            'available_providers' => $available_providers,
+            'available_providers' => array_values($available_providers), // Strip keys to prevent unintended array-to-object conversion
             'available_services' => $available_services,
             'secretary_providers' => $secretary_providers,
             'edit_appointment' => $edit_appointment,

--- a/assets/js/utils/calendar_table_view.js
+++ b/assets/js/utils/calendar_table_view.js
@@ -887,7 +887,7 @@ App.Utils.CalendarTableView = (function () {
         const workDateStart = moment(start.format('YYYY-MM-DD') + ' ' + workingPlan[selDayName].start);
 
         if (start < workDateStart) {
-            unavailabilityPeriod = {
+            const unavailabilityPeriod = {
                 title: lang('not_working'),
                 start: start.toDate(),
                 end: workDateStart.toDate(),


### PR DESCRIPTION
Greetings!

It seems that there are a few issues when running with "DEBUG_MODE = FALSE":

- When loading Table-view, following JavaScript error occurs:
`ReferenceError: unavailabilityPeriod is not defined  at createNonWorkingHours`
It seems that in calendar_table_view.js unavailabilityPeriod is missing it's declarative syntax. This is addressed in commit [e2fe600](https://github.com/alextselegidis/easyappointments/commit/e2fe600b943072411b6dbb77ead23db3b3124005)

- When logged in as service provider, loading appointments fails in calendar view with following error:
`TypeError: vars(...).find is not a function`
It seems that when available providers are gathered to page script variables (in Calendar controller), they are passed as associative array with id as key. Json_encode() -function transforms this as JSON array if keys are integer-like, but in release mode providers are filtered and might miss "0" -key. When that happens, json_encode() function generates a JSON object instead.  And Javascript objects do not have Array.prototype.find() -function. One way to fix is in commit [ad6bf65](https://github.com/alextselegidis/easyappointments/commit/ad6bf65667feaeef5cd645b74bbdc8c8dc033440.)

Here are my attempts to fix those issues, but I'm not so familiar with the code, so they might break something somewhere else.
