### PR TITLE
get_setting: If setting is 0, it is not a error.

### DIFF
--- a/application/models/Providers_model.php
+++ b/application/models/Providers_model.php
@@ -534,7 +534,7 @@ class Providers_model extends EA_Model {
     {
         $settings = $this->db->get_where('user_settings', ['id_users' => $provider_id])->row_array();
 
-        if (empty($settings[$name]))
+        if (!isset($settings[$name]))
         {
             throw new RuntimeException('The requested setting value was not found: ' . $provider_id);
         }


### PR DESCRIPTION
Problem recreation:

1. Add Service
2. Add Service Provider
3. Disable notifications from Service Provider
4. Add Service to Service Provider
5. Book appointment from added Service and Provider

Appointment will be added and Customer email is sent, but booking fails to Exception "The requested setting value was not found: 7"

Value that fails is 'notifications'.

DB returns array, but when notifications are disabled, the setting value is '0', that PHP empty() -function translates as TRUE.

Here is my suggestion to fix issue with isset()-function that will truly check whether specified property exists.