### PR TITLE
Add meta information for deactivation of automatic google translation

### DIFF
--- a/application/views/appointments/book.php
+++ b/application/views/appointments/book.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/appointments/book_success.php
+++ b/application/views/appointments/book_success.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/appointments/message.php
+++ b/application/views/appointments/message.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/backend/header.php
+++ b/application/views/backend/header.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="google" content="notranslate" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
     <title><?= isset($page_title) ? $page_title : lang('backend_section') ?> | Easy!Appointments</title>

--- a/application/views/general/error404.php
+++ b/application/views/general/error404.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/general/installation.php
+++ b/application/views/general/installation.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="google" content="notranslate" />
 
     <title>Installation | Easy!Appointments</title>
 

--- a/application/views/general/update.php
+++ b/application/views/general/update.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta name="google" content="notranslate" />
 
     <title>Update | Easy!Appointments</title>
 

--- a/application/views/user/forgot_password.php
+++ b/application/views/user/forgot_password.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/user/login.php
+++ b/application/views/user/login.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/user/logout.php
+++ b/application/views/user/logout.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">

--- a/application/views/user/no_privileges.php
+++ b/application/views/user/no_privileges.php
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#35A768">


### PR DESCRIPTION
Add meta information avoiding Google Translate in Chrome browser which detects wrong language because of html tag attribute lang="en".
See
#1360 