### PR TITLE
fix display of long unavailability notes

### DIFF
--- a/assets/js/utils/calendar_default_view.js
+++ b/assets/js/utils/calendar_default_view.js
@@ -1213,7 +1213,7 @@ App.Utils.CalendarDefaultView = (function () {
                     let notes = unavailability.notes ? ' - ' + unavailability.notes : '';
 
                     if (unavailability.notes && unavailability.notes.length > 30) {
-                        notes = unavailability.notes.substring(0, 30) + '...';
+                        notes = ' - ' + unavailability.notes.substring(0, 30) + '...';
                     }
 
                     const unavailabilityEvent = {


### PR DESCRIPTION
Long unavailability (more than 30 chars) are not correctly displayed in the calendar view.