### PR TITLE
Email Title Fix

### DIFF
--- a/application/libraries/Notifications.php
+++ b/application/libraries/Notifications.php
@@ -59,11 +59,11 @@ class Notifications {
         {
             if ($manage_mode)
             {
-                $customer_subject = lang('appointment_changes_saved');
+                $customer_subject = lang('appointment_details_changed');
 
                 $customer_message = '';
 
-                $provider_subject = lang('appointment_details_changed');
+                $provider_subject = lang('appointment_changes_saved');
 
                 $provider_message = '';
             }


### PR DESCRIPTION
When a provider changes the details of an appointment, they should recieve an email saying that the "Appointment changes have been successfully saved.", whereas the customer should recieve "Appointment details have changed.".

It seems to be the other way around right now.