### PR TITLE
Add missing `swedish` to `available_languages` in config.php

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -157,6 +157,7 @@ $config['available_languages'] = [
     'russian',
     'slovak',
     'spanish',
+    'swedish',
     'turkish'
 ];
 


### PR DESCRIPTION
Swedish language was listed in `$languages` but not in `$config['available_languages']`. This meant that if you selected another language than Swedish in the login portal, you could no longer go back to Swedish language. This commit fixes that.