### PR TITLE
Skip calendar attendee on empty email

### DIFF
--- a/application/libraries/Google_sync.php
+++ b/application/libraries/Google_sync.php
@@ -181,7 +181,7 @@ class Google_sync
         $event_provider->setEmail($provider['email']);
         $event->attendees[] = $event_provider;
 
-        if (!empty($customer)) {
+        if (!empty($customer['email'])) {
             $event_customer = new Google_Service_Calendar_EventAttendee();
             $event_customer->setDisplayName($customer['first_name'] . ' ' . $customer['last_name']);
             $event_customer->setEmail($customer['email']);
@@ -243,7 +243,7 @@ class Google_sync
         $event_provider->setEmail($provider['email']);
         $event->attendees[] = $event_provider;
 
-        if (!empty($customer)) {
+        if (!empty($customer['email'])) {
             $event_customer = new Google_Service_Calendar_EventAttendee();
             $event_customer->setDisplayName($customer['first_name'] . ' ' . $customer['last_name']);
             $event_customer->setEmail($customer['email']);

--- a/application/libraries/Google_sync.php
+++ b/application/libraries/Google_sync.php
@@ -181,7 +181,7 @@ class Google_sync
         $event_provider->setEmail($provider['email']);
         $event->attendees[] = $event_provider;
 
-        if (!empty($customer['email'])) {
+        if (isset($customer['email']) && !empty($customer['email'])) {
             $event_customer = new Google_Service_Calendar_EventAttendee();
             $event_customer->setDisplayName($customer['first_name'] . ' ' . $customer['last_name']);
             $event_customer->setEmail($customer['email']);
@@ -243,7 +243,7 @@ class Google_sync
         $event_provider->setEmail($provider['email']);
         $event->attendees[] = $event_provider;
 
-        if (!empty($customer['email'])) {
+        if (isset($customer['email']) && !empty($customer['email'])) {
             $event_customer = new Google_Service_Calendar_EventAttendee();
             $event_customer->setDisplayName($customer['first_name'] . ' ' . $customer['last_name']);
             $event_customer->setEmail($customer['email']);


### PR DESCRIPTION
Setting an event attendee without valid mail address causes an error:

```
ERROR - 2024-03-03 14:28:10 --> #0 /var/www/html/application/libraries/Notifications.php(111): Email_messages->send_appointment_saved(Array, Array, Array, Array, Array, 'Appointment det...', '', 'https://booking.s...', 'redacted@gm...', 'BEGIN:VCALENDAR...', 'Asia/Bangkok')
#1 /var/www/html/application/controllers/Calendar.php(278): Notifications->notify_appointment_saved(Array, Array, Array, Array, Array, true)
#2 /var/www/html/system/core/CodeIgniter.php(481): Calendar->save_appointment()
#3 /var/www/html/index.php(333): require_once('/var/www/html/s...
#4 {main}
ERROR - 2024-03-03 14:36:19 --> Could not find the language line "fields"
ERROR - 2024-03-03 14:39:32 --> Synchronization - Could not sync confirmation details of appointment (1) : {
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "invalid",
    "message": "Invalid attendee email."
   }
  ],
  "code": 400,
  "message": "Invalid attendee email."
 }
}
```

Reference for change:
https://developers.google.com/calendar/api/v3/reference/events/insert#:~:text=writable-,attendees%5B%5D.email,-string