### PR TITLE
Booking.js auto scroll

### DIFF
--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -419,8 +419,10 @@ App.Pages.Booking = (function () {
                 });
 
             // Scroll to the top of the page. Especially on a mobile device this is very useful.
-            const scrollingElement = (document.scrollingElement || document.body);
-            scrollingElement.scrollTop = 0;
+            if (window.innerWidth < 576) {
+                const scrollingElement = (document.scrollingElement || document.body);
+                scrollingElement.scrollTop = 0;
+            }
         });
 
         /**

--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -418,7 +418,7 @@ App.Pages.Booking = (function () {
                     $('#wizard-frame-' + nextTabIndex).fadeIn();
                 });
 
-            // Scroll to the top of the page. Especially on a mobile device this is very useful.
+            // Scroll to the top of the page. On a small screen, especially on a mobile device, this is very useful.
             const scrollingElement = (document.scrollingElement || document.body);
             if (window.innerHeight < scrollingElement.scrollHeight) {
                 scrollingElement.scrollTop = 0;

--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -668,7 +668,7 @@ App.Pages.Booking = (function () {
             <div>
                 <div class="mb-2 fw-bold fs-3">
                     ${serviceOptionText}
-                </div> 
+                </div>
                 <div class="mb-2 fw-bold text-muted">
                     ${providerOptionText}
                 </div>
@@ -679,16 +679,16 @@ App.Pages.Booking = (function () {
                 <div class="mb-2">
                     <i class="fas fa-calendar-day me-2"></i>
                     ${formattedSelectedDate}
-                </div> 
+                </div>
                 <div class="mb-2">
                     <i class="fas fa-globe me-2"></i>
                     ${timezoneOptionText}
-                </div> 
+                </div>
                 <div class="mb-2" ${!Number(service.price) ? 'hidden' : ''}>
                     <i class="fas fa-cash-register me-2"></i>
                     ${Number(service.price).toFixed(2)} ${service.currency}
                 </div>
-            </div>     
+            </div>
         `);
 
         // Render the customer information

--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -417,6 +417,10 @@ App.Pages.Booking = (function () {
                     $('#step-' + nextTabIndex).addClass('active-step');
                     $('#wizard-frame-' + nextTabIndex).fadeIn();
                 });
+
+            // Scroll to the top of the page. Especially on a mobile device this is very useful.
+            const scrollingElement = (document.scrollingElement || document.body);
+            scrollingElement.scrollTop = 0;
         });
 
         /**

--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -419,8 +419,8 @@ App.Pages.Booking = (function () {
                 });
 
             // Scroll to the top of the page. Especially on a mobile device this is very useful.
-            if (window.innerWidth < 576) {
-                const scrollingElement = (document.scrollingElement || document.body);
+            const scrollingElement = (document.scrollingElement || document.body);
+            if (window.innerHeight < scrollingElement.scrollHeight) {
                 scrollingElement.scrollTop = 0;
             }
         });


### PR DESCRIPTION
Scroll screen to top of the page. Especially on a mobile device this is very useful.
When you move forward on tabs on a mobile device,  you'd have to manually scroll to the top of the page.
This PR scrolls automatically to the top of the page on forward move.
On backward move, there is no auto scroll because you know what was the content on the previous tab.
