### PR TITLE
Email with status

### DIFF
--- a/application/libraries/Email_messages.php
+++ b/application/libraries/Email_messages.php
@@ -73,12 +73,15 @@ class Email_messages
         string $recipient_email,
         string $ics_stream,
         string $timezone = null,
+        string $status = null,
     ): void {
         $appointment_timezone = new DateTimeZone($provider['timezone']);
 
         $appointment_start = new DateTime($appointment['start_datetime'], $appointment_timezone);
 
         $appointment_end = new DateTime($appointment['end_datetime'], $appointment_timezone);
+
+        $status = $appointment['status'];
 
         if ($timezone && $timezone !== $provider['timezone']) {
             $custom_timezone = new DateTimeZone($timezone);
@@ -93,6 +96,7 @@ class Email_messages
         $html = $this->CI->load->view(
             'emails/appointment_saved_email',
             [
+                'status' => $status,
                 'subject' => $subject,
                 'message' => $message,
                 'appointment' => $appointment,

--- a/application/views/emails/appointment_saved_email.php
+++ b/application/views/emails/appointment_saved_email.php
@@ -2,6 +2,7 @@
 /**
  * Local variables.
  *
+ * @var string $status
  * @var string $subject
  * @var string $message
  * @var array $appointment
@@ -43,6 +44,14 @@
         </h2>
 
         <table id="appointment-details">
+            <tr>
+                <td class="label" style="padding: 3px;font-weight: bold;">
+                    <?= lang('status') ?>
+                </td>
+                <td style="padding: 3px;">
+                    <?= e($status) ?>
+                </td>
+            </tr>
             <tr>
                 <td class="label" style="padding: 3px;font-weight: bold;">
                     <?= lang('service') ?>


### PR DESCRIPTION
If appointment status is changed with no other changes, there will be an email, but there is no information what has been changed, as status is not included in the email body.

This PR adds status to email.