### PR TITLE
Blocked periods in settings

### DIFF
--- a/assets/js/pages/blocked_periods.js
+++ b/assets/js/pages/blocked_periods.js
@@ -80,6 +80,7 @@ App.Pages.BlockedPeriods = (function () {
             $blockedPeriods.find('.record-details .form-label span').prop('hidden', false);
             $filterBlockedPeriods.find('button').prop('disabled', true);
             $filterBlockedPeriods.find('.results').css('color', '#AAA');
+            App.Utils.UI.setDateTimePickerValue($startDateTime, new Date(moment().format('YYYY-MM-DD 00:00')));
         });
 
         /**
@@ -154,6 +155,16 @@ App.Pages.BlockedPeriods = (function () {
             resetForm();
             if (id !== '') {
                 select(id, true);
+            }
+        });
+
+        /**
+         * Event: start-date-time "Change"
+         */
+        $startDateTime.on('change', () => {
+            // If endDateTime is not yet set, set it to the end of day at startDateTime
+            if (typeof(App.Utils.UI.getDateTimePickerValue($endDateTime)) === "undefined") {
+                App.Utils.UI.setDateTimePickerValue($endDateTime, new Date(moment(App.Utils.UI.getDateTimePickerValue($startDateTime)).format('YYYY-MM-DD 24:00')));
             }
         });
     }

--- a/assets/js/pages/blocked_periods.js
+++ b/assets/js/pages/blocked_periods.js
@@ -164,7 +164,7 @@ App.Pages.BlockedPeriods = (function () {
         $startDateTime.on('change', () => {
             // If endDateTime is not yet set, set it to the end of day at startDateTime
             if (typeof(App.Utils.UI.getDateTimePickerValue($endDateTime)) === "undefined") {
-                App.Utils.UI.setDateTimePickerValue($endDateTime, new Date(moment(App.Utils.UI.getDateTimePickerValue($startDateTime)).format('YYYY-MM-DD 24:00')));
+                App.Utils.UI.setDateTimePickerValue($endDateTime, new Date(moment(App.Utils.UI.getDateTimePickerValue($startDateTime)).add(1, 'day')));
             }
         });
     }


### PR DESCRIPTION
Give $startDateTime a default value (today 00:00), and when $startDateTime changes, sets $enddateTime to +1 day if $enddateTime is not yet set.

Is is quite safe to assume that a blocked period like a holiday lasts for 24 hours.

User can set other hours, if needed.