### PR TITLE
Use company_working_plan hours instead of hardcoded hours

### DIFF
--- a/application/language/arabic/translations_lang.php
+++ b/application/language/arabic/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/bulgarian/translations_lang.php
+++ b/application/language/bulgarian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/catalan/translations_lang.php
+++ b/application/language/catalan/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/chinese/translations_lang.php
+++ b/application/language/chinese/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/croatian/translations_lang.php
+++ b/application/language/croatian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/czech/translations_lang.php
+++ b/application/language/czech/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/danish/translations_lang.php
+++ b/application/language/danish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/dutch/translations_lang.php
+++ b/application/language/dutch/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/english/translations_lang.php
+++ b/application/language/english/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/estonian/translations_lang.php
+++ b/application/language/estonian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/finnish/translations_lang.php
+++ b/application/language/finnish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Työsuunnitelman poikkeuksen alkamisajan on oltava ennen päättymisaikaa.';
 // End

--- a/application/language/french/translations_lang.php
+++ b/application/language/french/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/german/translations_lang.php
+++ b/application/language/german/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/greek/translations_lang.php
+++ b/application/language/greek/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/hebrew/translations_lang.php
+++ b/application/language/hebrew/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/hindi/translations_lang.php
+++ b/application/language/hindi/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/hungarian/translations_lang.php
+++ b/application/language/hungarian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/italian/translations_lang.php
+++ b/application/language/italian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/japanese/translations_lang.php
+++ b/application/language/japanese/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/luxembourgish/translations_lang.php
+++ b/application/language/luxembourgish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/marathi/translations_lang.php
+++ b/application/language/marathi/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/persian/translations_lang.php
+++ b/application/language/persian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/polish/translations_lang.php
+++ b/application/language/polish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/portuguese-br/translations_lang.php
+++ b/application/language/portuguese-br/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/portuguese/translations_lang.php
+++ b/application/language/portuguese/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/romanian/translations_lang.php
+++ b/application/language/romanian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/russian/translations_lang.php
+++ b/application/language/russian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/serbian/translations_lang.php
+++ b/application/language/serbian/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/slovak/translations_lang.php
+++ b/application/language/slovak/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/spanish/translations_lang.php
+++ b/application/language/spanish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/swedish/translations_lang.php
+++ b/application/language/swedish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/thai/translations_lang.php
+++ b/application/language/thai/translations_lang.php
@@ -454,4 +454,5 @@ $lang['sync_method_prompt'] = 'คุณต้องการใช้วิธ�
 $lang['caldav_server'] = 'เซิร์ฟเวอร์ CalDAV';
 $lang['caldav_connection_info_prompt'] = 'โปรดป้อนข้อมูลการเชื่อมต่อของเซิร์ฟเวอร์ CalDAV เป้าหมาย';
 $lang['connect'] = 'เชื่อมต่อ';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/language/turkish/translations_lang.php
+++ b/application/language/turkish/translations_lang.php
@@ -453,4 +453,5 @@ $lang['webhook_saved'] = 'Webhook saved successfully.';
 $lang['webhook_deleted'] = 'Webhook deleted successfully.';
 $lang['delete_webhook'] = 'Delete Webhook';
 $lang['contact_info'] = 'Contact Info';
+$lang['working_plan_exception_start_before_end'] = 'Working plan exception start date must be before the end date.';
 // End

--- a/application/models/Providers_model.php
+++ b/application/models/Providers_model.php
@@ -502,7 +502,7 @@ class Providers_model extends EA_Model
         $end = date('H:i', strtotime($working_plan_exception['end']));
 
         if ($start > $end) {
-            throw new InvalidArgumentException('Working plan exception start date must be before the end date.');
+            throw new InvalidArgumentException(lang('working_plan_exception_start_before_end'));
         }
 
         // Make sure the provider record exists.

--- a/assets/js/components/working_plan_exceptions_modal.js
+++ b/assets/js/components/working_plan_exceptions_modal.js
@@ -216,8 +216,12 @@ App.Components.WorkingPlanExceptionsModal = (function () {
     }
 
     function resetTimeSelection() {
-        App.Utils.UI.setDateTimePickerValue($start, moment('08:00', 'HH:mm').toDate());
-        App.Utils.UI.setDateTimePickerValue($end, moment('20:00', 'HH:mm').toDate());
+        const company_working_plan = JSON.parse(vars('company_working_plan'));
+        let weekDay = moment().day();
+        weekDay = App.Utils.Date.getWeekdayName(weekDay);
+        
+        App.Utils.UI.setDateTimePickerValue($start, moment(company_working_plan[weekDay]['start'], 'HH:mm').toDate());
+        App.Utils.UI.setDateTimePickerValue($end, moment(company_working_plan[weekDay]['end'], 'HH:mm').toDate());
     }
 
     /**

--- a/assets/js/components/working_plan_exceptions_modal.js
+++ b/assets/js/components/working_plan_exceptions_modal.js
@@ -216,13 +216,25 @@ App.Components.WorkingPlanExceptionsModal = (function () {
     }
 
     function resetTimeSelection() {
-        const company_working_plan = JSON.parse(vars('company_working_plan'));
-        let weekDay = moment().day();
-        weekDay = App.Utils.Date.getWeekdayName(weekDay);
-        
-        App.Utils.UI.setDateTimePickerValue($start, moment(company_working_plan[weekDay]['start'], 'HH:mm').toDate());
-        App.Utils.UI.setDateTimePickerValue($end, moment(company_working_plan[weekDay]['end'], 'HH:mm').toDate());
+        const dateTimeObject = App.Utils.UI.getDateTimePickerValue($date);
+        const plannedHours = getWeekdaysPlannedHours(App.Utils.Date.getWeekdayName(moment(dateTimeObject).day()));
+        App.Utils.UI.setDateTimePickerValue($start, moment(plannedHours['start'], 'HH:mm').toDate());
+        App.Utils.UI.setDateTimePickerValue($end, moment(plannedHours['end'], 'HH:mm').toDate());
     }
+
+    function getWeekdaysPlannedHours(weekDay) {
+        hours = {};
+        const company_working_plan = JSON.parse(vars('company_working_plan'));
+        if (company_working_plan[weekDay]) {
+            hours["start"] = company_working_plan[weekDay]['start'];
+            hours["end"] = company_working_plan[weekDay]['end'];
+        } else {
+            hours["start"] = '08:00';
+            hours["end"] = '20:00';
+        }
+        return hours;
+    }
+
 
     /**
      * Open the modal and start adding a new working plan exception.
@@ -276,8 +288,9 @@ App.Components.WorkingPlanExceptionsModal = (function () {
                 $breaks.find('tbody .working-plan-exceptions-break-start, tbody .working-plan-exceptions-break-end'),
             );
         } else {
-            App.Utils.UI.setDateTimePickerValue($start, moment('08:00', 'HH:mm').toDate());
-            App.Utils.UI.setDateTimePickerValue($end, moment('20:00', 'HH:mm').toDate());
+            const plannedHours = getWeekdaysPlannedHours(App.Utils.Date.getWeekdayName(moment(date).day()));
+            App.Utils.UI.setDateTimePickerValue($start, moment(plannedHours['start'], 'HH:mm').toDate());
+            App.Utils.UI.setDateTimePickerValue($end, moment(plannedHours['end'], 'HH:mm').toDate());
             $breaks.find('tbody').html(renderNoBreaksRow());
         }
 
@@ -459,6 +472,16 @@ App.Components.WorkingPlanExceptionsModal = (function () {
     }
 
     /**
+     * Event: Edit Date "Change"
+     */
+    function onEditDateChange() {
+        const dateTimeObject = App.Utils.UI.getDateTimePickerValue($date);
+        const plannedHours = getWeekdaysPlannedHours(App.Utils.Date.getWeekdayName(moment(dateTimeObject).day()));
+        App.Utils.UI.setDateTimePickerValue($start, moment(plannedHours['start'], 'HH:mm').toDate());
+        App.Utils.UI.setDateTimePickerValue($end, moment(plannedHours['end'], 'HH:mm').toDate());
+    }
+
+    /**
      * Event: Is Non-Working Day "Change"
      */
     function onIsNonWorkingDayChange() {
@@ -481,7 +504,8 @@ App.Components.WorkingPlanExceptionsModal = (function () {
             .on('click', '.working-plan-exceptions-edit-break', onEditBreakClick)
             .on('click', '.working-plan-exceptions-delete-break', onDeleteBreakClick)
             .on('click', '.working-plan-exceptions-save-break', onSaveBreakClick)
-            .on('click', '.working-plan-exceptions-cancel-break', onCancelBreakClick);
+            .on('click', '.working-plan-exceptions-cancel-break', onCancelBreakClick)
+            .on('change', '#working-plan-exceptions-date', onEditDateChange);
 
         $save.on('click', onSaveClick);
 


### PR DESCRIPTION
Instead of using hardcoded start end end hours for working_plan_exceptions, it would be better to use company_working_plan start end and hours for that weekday. when resetting the form. Company plan is the baseline where the user is making an exception.