### PR TITLE
Feat Dynamic Fields TimeZone & Language for new users

### DIFF
--- a/assets/js/components/appointments_modal.js
+++ b/assets/js/components/appointments_modal.js
@@ -424,8 +424,8 @@ App.Components.AppointmentsModal = (function () {
             $address.val('');
             $city.val('');
             $zipCode.val('');
-            $language.val('english');
-            $timezone.val('UTC');
+            $language.val(vars('language') || 'english');
+            $timezone.val(moment.tz.guess() || 'UTC');
             $customerNotes.val('');
             $customField1.val('');
             $customField2.val('');
@@ -449,8 +449,8 @@ App.Components.AppointmentsModal = (function () {
         const defaultStatusValue = $appointmentStatus.find('option:first').val();
         $appointmentStatus.val(defaultStatusValue);
 
-        $language.val('english');
-        $timezone.val('UTC');
+        $language.val(vars('language') || 'english');
+        $timezone.val(moment.tz.guess() || 'UTC');
 
         // Reset color.
         $appointmentColor.find('.color-selection-option:first').trigger('click');

--- a/assets/js/pages/admins.js
+++ b/assets/js/pages/admins.js
@@ -336,8 +336,8 @@ App.Pages.Admins = (function () {
         $admins.find('.record-details').find('input, select, textarea').val('').prop('disabled', true);
         $admins.find('.record-details .form-label span').prop('hidden', true);
         $admins.find('.record-details #calendar-view').val('default');
-        $admins.find('.record-details #language').val('english');
-        $admins.find('.record-details #timezone').val('UTC');
+        $admins.find('.record-details #language').val(vars('language') || 'english');
+        $admins.find('.record-details #timezone').val(moment.tz.guess() || 'UTC');
         $admins.find('.record-details #notifications').prop('checked', true);
         $('#edit-admin, #delete-admin').prop('disabled', true);
 

--- a/assets/js/pages/customers.js
+++ b/assets/js/pages/customers.js
@@ -252,9 +252,8 @@ App.Pages.Customers = (function () {
     function resetForm() {
         $customers.find('.record-details').find('input, select, textarea').val('').prop('disabled', true);
         $customers.find('.record-details .form-label span').prop('hidden', true);
-        $customers.find('.record-details #timezone').val('UTC');
-
-        $language.val('english');
+        $customers.find('.record-details #timezone').val(moment.tz.guess() || 'UTC');
+        $customers.find('.record-details #language').val(vars('language') || 'english');
 
         $customerAppointments.empty();
 

--- a/assets/js/pages/providers.js
+++ b/assets/js/pages/providers.js
@@ -340,8 +340,8 @@ App.Pages.Providers = (function () {
         $providers.find('.record-details').find('input, select, textarea').val('').prop('disabled', true);
         $providers.find('.record-details .form-label span').prop('hidden', true);
         $providers.find('.record-details #calendar-view').val('default');
-        $providers.find('.record-details #language').val('english');
-        $providers.find('.record-details #timezone').val('UTC');
+        $providers.find('.record-details #language').val(vars('language') || 'english');
+        $providers.find('.record-details #timezone').val(moment.tz.guess() || 'UTC');
         $providers.find('.record-details #is-private').prop('checked', false);
         $providers.find('.record-details #notifications').prop('checked', true);
         $providers.find('.add-break, .add-working-plan-exception, #reset-working-plan').prop('disabled', true);

--- a/assets/js/pages/secretaries.js
+++ b/assets/js/pages/secretaries.js
@@ -344,7 +344,8 @@ App.Pages.Secretaries = (function () {
         $secretaries.find('.record-details').find('input, select, textarea').val('').prop('disabled', true);
         $secretaries.find('.record-details .form-label span').prop('hidden', true);
         $secretaries.find('.record-details #calendar-view').val('default');
-        $secretaries.find('.record-details #timezone').val('UTC');
+        $secretaries.find('.record-details #language').val(vars('language') || 'english');
+        $secretaries.find('.record-details #timezone').val(moment.tz.guess() || 'UTC');
         $secretaries.find('.record-details #notifications').prop('checked', true);
         $secretaries.find('.add-edit-delete-group').show();
         $secretaries.find('.save-cancel-group').hide();


### PR DESCRIPTION
+ Language by `vars('language')`
+ + When add a user, the selected lang is same as back office lang
+ + Note : when change lang with bottom selector, go to default lang

+ Timezone by `moment.tz.guess()`
+ + See : https://stackoverflow.com/questions/1091372/getting-the-clients-time-zone-and-offset-in-javascript#40435316

`Fix empty field language val for secretaries admin page`

More usefull and maybe for #1386 #1476 & #1390