### PR TITLE
Fix refresh Appointments MONTH calendarView : current2active

### DIFF
--- a/assets/js/utils/calendar_default_view.js
+++ b/assets/js/utils/calendar_default_view.js
@@ -56,8 +56,8 @@ App.Utils.CalendarDefaultView = (function () {
                 $calendar,
                 $selectFilterItem.val(),
                 $selectFilterItem.find('option:selected').attr('type'),
-                calendarView.currentStart,
-                calendarView.currentEnd,
+                calendarView.activeStart,
+                calendarView.activeEnd,
             );
         });
 
@@ -1153,8 +1153,8 @@ App.Utils.CalendarDefaultView = (function () {
             $calendar,
             $selectFilterItem.val(),
             $('#select-filter-item option:selected').attr('type'),
-            fullCalendar.view.currentStart,
-            fullCalendar.view.currentEnd,
+            fullCalendar.view.activeStart,
+            fullCalendar.view.activeEnd,
         );
 
         $(window).trigger('resize'); // Places the footer on the bottom.
@@ -1641,8 +1641,8 @@ App.Utils.CalendarDefaultView = (function () {
                 $calendar,
                 $selectFilterItem.val(),
                 $selectFilterItem.find('option:selected').attr('type'),
-                fullCalendar.view.currentStart,
-                fullCalendar.view.currentEnd,
+                fullCalendar.view.activeStart,
+                fullCalendar.view.activeEnd,
             );
         }, 60000);
     }


### PR DESCRIPTION
Fix no displayed appointments if not in this current month
and if moved by D&D on prev/next month days view (displace OK),
but after auto refresh, appointment disappear in view... 

After little fear, it exist in db :)
Need to choose prev/next month (where is moved) to see it.

see https://fullcalendar.io/docs/view-object