### PR TITLE
Fix CodeIgniter creating a lot of session files

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -353,7 +353,7 @@ $config['sess_expiration'] = 7200;
 $config['sess_save_path'] = __DIR__ . '/../../storage/sessions';
 $config['sess_match_ip'] = false;
 $config['sess_time_to_update'] = 300;
-$config['sess_regenerate_destroy'] = false;
+$config['sess_regenerate_destroy'] = true;
 
 /*
 |--------------------------------------------------------------------------

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -124,7 +124,7 @@ class CI_Session {
 			unset($_COOKIE[$this->_config['cookie_name']]);
 		}
 
-		@session_start();
+		session_start();
 
 		// Is session ID auto-regeneration configured? (ignoring ajax requests)
 		if ((empty($_SERVER['HTTP_X_REQUESTED_WITH']) OR strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest')
@@ -137,7 +137,7 @@ class CI_Session {
 			}
 			elseif ($_SESSION['__ci_last_regenerate'] < (time() - $regenerate_time))
 			{
-				$this->sess_regenerate((bool) config_item('sess_regenerate_destroy'));
+				$this->sess_regenerate();
 			}
 		}
 		// Another work-around ... PHP doesn't seem to send the session cookie
@@ -691,8 +691,9 @@ class CI_Session {
 	 * @param	bool	$destroy	Destroy old session data flag
 	 * @return	void
 	 */
-	public function sess_regenerate($destroy = FALSE)
+	public function sess_regenerate($destroy = null)
 	{
+		$destroy = (bool) $destroy !== null ? $destroy : config_item('sess_regenerate_destroy');
 		$_SESSION['__ci_last_regenerate'] = time();
 		session_regenerate_id($destroy);
 	}

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -693,7 +693,7 @@ class CI_Session {
 	 */
 	public function sess_regenerate($destroy = null)
 	{
-		$destroy = (bool) $destroy !== null ? $destroy : config_item('sess_regenerate_destroy');
+		$destroy = boolval($destroy !== null ? $destroy : config_item('sess_regenerate_destroy'));
 		$_SESSION['__ci_last_regenerate'] = time();
 		session_regenerate_id($destroy);
 	}


### PR DESCRIPTION
Fix When login CI call `sess_regenerate()`
but do not apply config 'sess_regenerate_destroy' & always create new file

After this, a session folder have one file by user logged
and clean old session files in `storage/sessions` folder

To test : in application/config.php
`$config['sess_time_to_update'] = 3;`

see
https://bobcares.com/blog/codeigniter-generating-too-many-sessions-files-resolved