### PR TITLE
Fix App lib Timezones::get_default_timezone() always UTC

### DIFF
--- a/application/libraries/Timezones.php
+++ b/application/libraries/Timezones.php
@@ -530,7 +530,7 @@ class Timezones
      */
     public function get_default_timezone(): string
     {
-        return 'UTC';
+        return date_default_timezone_get();
     }
 
     /**


### PR DESCRIPTION
[If none of the above succeed, will return a default timezone of UTC.](https://www.php.net/manual/en/function.date-default-timezone-get.php)

