### PR TITLE
Update Dockerfile to php:8.3.7

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.3.7-apache
 
 WORKDIR "/var/www/html"
 


### PR DESCRIPTION
When running the application, it was giving an error because it had an old version of PHP

------
ERROR [server 4/5] RUN pecl install xdebug     && docker-php-ext-enab  2.7s 
> [server 4/5] RUN pecl install xdebug     && docker-php-ext-enable xdebug:
2.606 WARNING: channel "pecl.php.net" has updated its protocols, use "pecl channel-update pecl.php.net" to update
2.615 pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.3.99), installed version is 7.4.33
2.615 No valid packages found
2.615 install failed
failed to solve: process "/bin/sh -c pecl install xdebug     && docker-php-ext-enable xdebug" did not complete successfully: exit code: 1
------