### PR TITLE
Update Providers_model.php

### DIFF
--- a/application/models/Providers_model.php
+++ b/application/models/Providers_model.php
@@ -524,9 +524,9 @@ class Providers_model extends EA_Model
         array $working_plan_exception = null,
     ): void {
         // Validate the working plan exception data.
-        $start = date('H:i', strtotime($working_plan_exception['start']));
+        $start = (!empty($working_plan_exception['start']) ? date('H:i', strtotime($working_plan_exception['start'])) : null);
 
-        $end = date('H:i', strtotime($working_plan_exception['end']));
+        $end = (!empty($working_plan_exception['end']) ? date('H:i', strtotime($working_plan_exception['end'])) : null);
 
         if ($start > $end) {
             throw new InvalidArgumentException('Working plan exception start date must be before the end date.');


### PR DESCRIPTION
To handle deprecations on lines 527 and 529.
`strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated `
When there is a full-day exception, `$working_plan_exception['start']` and `$working_plan_exception['end']` are both `null`

This is an issue that came up on  #1497 and at some point it seemed to be cleared, so I closed #1497.
Now it is back, and now I can explain more precisely the conditions it occurs.

First of all it is not an exception but a deprecation, but if handled now there would be no exceptions later on with future php versions.

This appears under the following conditions:
1) in `config.php` there is `const DEBUG_MODE = true;` and
2)  `error_reporting` in `php.ini` has been set to report deprecations.

Maybe this is the reason you did not see this. In my case both conditions were met.


