### PR TITLE
Handling 'This provider will not be available for work on the selected day.'

### DIFF
--- a/application/models/Providers_model.php
+++ b/application/models/Providers_model.php
@@ -525,15 +525,16 @@ class Providers_model extends EA_Model
     ): void {
         // Validate the working plan exception data.
 
-        if (empty($working_plan_exception['start']) || empty($working_plan_exception['end'])) {
+        if (empty($working_plan_exception)){
+            $start = $end = null;
+        } elseif (empty($working_plan_exception['start']) || empty($working_plan_exception['end'])) {
             throw new InvalidArgumentException(
                 'Empty start and/or end time provided: ' . json_encode($working_plan_exception),
             );
+        } else {
+            $start = date('H:i', strtotime($working_plan_exception['start']));
+            $end = date('H:i', strtotime($working_plan_exception['end']));
         }
-
-        $start = date('H:i', strtotime($working_plan_exception['start']));
-
-        $end = date('H:i', strtotime($working_plan_exception['end']));
 
         if ($start > $end) {
             throw new InvalidArgumentException('Working plan exception start date must be before the end date.');
@@ -599,7 +600,7 @@ class Providers_model extends EA_Model
      *
      * @throws Exception If $provider_id argument is invalid.
      */
-    public function delete_working_plan_exception(int $provider_id, string $date): void
+    public function delete_working_plan_exception(int $provider_id, ?string $date): void
     {
         $provider = $this->find($provider_id);
 


### PR DESCRIPTION
If 'This provider will not be available for work on the selected day.' is selected when creating an working plan exception, `$working_plan_exception` is null in function save_working_plan_exception starting from line 521.

Also, it is necessary to allow null value for parameter `$date` in function `delete_working_plan_exception`