### PR TITLE
Add basic e-mail settings to config.php

### DIFF
--- a/application/config/email.php
+++ b/application/config/email.php
@@ -4,18 +4,18 @@
 // Example: $config['smtp_host'] = 'smtp.gmail.com';
 // @link https://codeigniter.com/user_guide/libraries/email.html
 
-$config['useragent'] = 'Easy!Appointments';
-$config['protocol'] = 'mail'; // or 'smtp'
-$config['mailtype'] = 'html'; // or 'text'
-// $config['smtp_debug'] = '0'; // or '1'
-// $config['smtp_auth'] = TRUE; //or FALSE for anonymous relay.
-// $config['smtp_host'] = '';
-// $config['smtp_user'] = '';
-// $config['smtp_pass'] = '';
-// $config['smtp_crypto'] = 'ssl'; // or 'tls'
-// $config['smtp_port'] = 25;
-// $config['from_name'] = '';
-// $config['from_address'] = '';
-// $config['reply_to'] = '';
+$config['useragent'] = Config::EMAIL_USERAGENT;
+$config['protocol'] =  Config::EMAIL_PROTOCOL;
+$config['mailtype'] = Config::EMAIL_MAILTYPE;
+$config['smtp_debug'] = Config::EMAIL_SMTP_DEBUG;
+$config['smtp_auth'] = Config::EMAIL_SMTP_AUTH;
+$config['smtp_host'] = Config::EMAIL_SMTP_HOST;
+$config['smtp_user'] = Config::EMAIL_SMTP_USER;
+$config['smtp_pass'] = Config::EMAIL_SMTP_PASS;
+$config['smtp_crypto'] =  Config::EMAIL_SMTP_CRYPTO;
+$config['smtp_port'] = Config::EMAIL_SMTP_PORT;
+$config['from_name'] = Config::EMAIL_FROM_NAME;
+$config['from_address'] = Config::EMAIL_FROM_ADDRESS;
+$config['reply_to'] = Config::EMAIL_REPLY_TO;
 $config['crlf'] = "\r\n";
 $config['newline'] = "\r\n";

--- a/config-sample.php
+++ b/config-sample.php
@@ -50,4 +50,37 @@ class Config
     const GOOGLE_SYNC_FEATURE = false; // Enter TRUE or FALSE
     const GOOGLE_CLIENT_ID = '';
     const GOOGLE_CLIENT_SECRET = '';
+
+    // ------------------------------------------------------------------------
+    // E-MAIL SETTINGS
+    // ------------------------------------------------------------------------
+
+    // Add custom values by settings them to the $config array in application/config/email.php.
+    // @link https://codeigniter.com/user_guide/libraries/email.html
+
+    const EMAIL_USERAGENT = 'Easy!Appointments';
+    const EMAIL_PROTOCOL = 'mail'; // or 'smtp'
+    const EMAIL_MAILTYPE = 'html';  // or 'text'
+    const EMAIL_SMTP_DEBUG = '0';  // or '1'
+    const EMAIL_SMTP_AUTH = TRUE; //or FALSE for anonymous relay.
+    const EMAIL_SMTP_HOST = '';
+    const EMAIL_SMTP_USER = '';
+    const EMAIL_SMTP_PASS = '';
+    const EMAIL_SMTP_CRYPTO = 'ssl';
+    const EMAIL_SMTP_PORT = 25;
+    const EMAIL_FROM_NAME = '';
+    const EMAIL_FROM_ADDRESS = '';
+    const EMAIL_REPLY_TO = '';
+
+
+    /* Example Exchange OnPremise 2019
+    const EMAIL_PROTOCOL = 'smtp'; // or 'smtp'
+    const EMAIL_SMTP_AUTH = TRUE; //or FALSE for anonymous relay.
+    const EMAIL_SMTP_HOST = ''; // hostname
+    const EMAIL_SMTP_USER = ''; // e-mail
+    const EMAIL_SMTP_PASS = ''; // password
+    const EMAIL_SMTP_CRYPTO = 'tls'; // STARTTLS necessary
+    const EMAIL_SMTP_PORT = 587;
+    const EMAIL_FROM_ADDRESS = ''; // e-mail
+    */
 }


### PR DESCRIPTION
It seems easier to update if any custom setting is contained inside config.php and thus don't get overwritten, as such I added the basic e-mail settings to config.php (see config-sample.php). Additionally I added a example for configuring exchange as a smtp server.

Please feel free to tell me, if I should change anything to get it merged.