### PR TITLE
Add ability to hide notes of synced calender entries

### DIFF
--- a/application/config/google.php
+++ b/application/config/google.php
@@ -15,3 +15,6 @@ $config['google_sync_feature'] = Config::GOOGLE_SYNC_FEATURE;
 $config['google_client_id'] = Config::GOOGLE_CLIENT_ID;
 
 $config['google_client_secret'] = Config::GOOGLE_CLIENT_SECRET;
+
+$config['google_hide_notes'] = Config::GOOGLE_HIDE_NOTES;
+

--- a/application/controllers/Caldav.php
+++ b/application/controllers/Caldav.php
@@ -229,6 +229,8 @@ class Caldav extends EA_Controller
             }
         }
 
+        $hide_notes = config('google_hide_notes');
+
         foreach ($caldav_events as $caldav_event) {
             if ($caldav_event['status'] === 'CANCELLED') {
                 continue;
@@ -258,7 +260,7 @@ class Caldav extends EA_Controller
                 'start_datetime' => $caldav_event['start_datetime'],
                 'end_datetime' => $caldav_event['end_datetime'],
                 'location' => $caldav_event['location'],
-                'notes' => $caldav_event['summary'] . ' ' . $caldav_event['description'],
+                'notes' => $hide_notes ? "External" : $caldav_event['summary'] . ' ' . $caldav_event['description'],
                 'id_users_provider' => $provider_id,
                 'id_caldav_calendar' => $caldav_event['id'],
             ];

--- a/application/controllers/Google.php
+++ b/application/controllers/Google.php
@@ -202,6 +202,8 @@ class Google extends EA_Controller
                 }
             }
 
+            $hide_notes = config('google_hide_notes');
+
             foreach ($google_events->getItems() as $google_event) {
                 if ($google_event->getStatus() === 'cancelled') {
                     continue;
@@ -240,7 +242,7 @@ class Google extends EA_Controller
                     'end_datetime' => $google_event_end->format('Y-m-d H:i:s'),
                     'is_unavailability' => true,
                     'location' => $google_event->getLocation(),
-                    'notes' => $google_event->getSummary() . ' ' . $google_event->getDescription(),
+                    'notes' => $hide_notes ? "External" : $google_event->getSummary() . ' ' . $google_event->getDescription(),
                     'id_users_provider' => $provider_id,
                     'id_google_calendar' => $google_event->getId(),
                     'id_users_customer' => null,

--- a/config-sample.php
+++ b/config-sample.php
@@ -50,4 +50,5 @@ class Config
     const GOOGLE_SYNC_FEATURE = false; // Enter TRUE or FALSE
     const GOOGLE_CLIENT_ID = '';
     const GOOGLE_CLIENT_SECRET = '';
+    const GOOGLE_HIDE_NOTES = false;
 }


### PR DESCRIPTION
Add ability to hide notes of synced calender entries, if these shouldn't be visible to others.