### PR TITLE
fix loop when going a month back in an edge case

### DIFF
--- a/assets/js/http/booking_http_client.js
+++ b/assets/js/http/booking_http_client.js
@@ -284,7 +284,7 @@ App.Http.Booking = (function () {
 
                         while (startOfMonthMoment.isSameOrBefore(endOfMonthMoment)) {
                             unavailableDates.push(startOfMonthMoment.format('YYYY-MM-DD'));
-                            startOfMonthMoment.add(monthChangeStep, 'days'); // Move to the next day
+                            startOfMonthMoment.add(Math.abs(monthChangeStep), 'days'); // Move to the next day
                         }
 
                         applyUnavailableDates(unavailableDates, searchedMonthStart, true);


### PR DESCRIPTION
If you are switching back from a month further ahead the variable monthChangeStep is -1 it loops in line 285 to 288 in booking_http_client endlessly.