### PR TITLE
Fix ICS file mimetype

### DIFF
--- a/application/libraries/Email_messages.php
+++ b/application/libraries/Email_messages.php
@@ -114,7 +114,7 @@ class Email_messages
 
         $php_mailer = $this->get_php_mailer($recipient_email, $subject, $html);
 
-        $php_mailer->addStringAttachment($ics_stream, 'invitation.ics', PHPMailer::ENCODING_BASE64, 'text/vcalendar');
+        $php_mailer->addStringAttachment($ics_stream, 'invitation.ics', PHPMailer::ENCODING_BASE64, 'text/calendar');
 
         $php_mailer->send();
     }


### PR DESCRIPTION
`text/vcalendar` isn't a valid MIME type.  The correct one is `text/calendar`. This difference causes opening ICS files in Thunderbird/K-9 Mail on Android to not show any calendar app as able to open the file.