### PR TITLE
Fixed reopening appointments modal with alert message active

### DIFF
--- a/assets/js/components/appointments_modal.js
+++ b/assets/js/components/appointments_modal.js
@@ -445,6 +445,7 @@ App.Components.AppointmentsModal = (function () {
         // Empty form fields.
         $appointmentsModal.find('input, textarea').val('');
         $appointmentsModal.find('.modal-message').addClass('.d-none');
+        $appointmentsModal.find('.is-invalid').removeClass('is-invalid');
 
         const defaultStatusValue = $appointmentStatus.find('option:first').val();
         $appointmentStatus.val(defaultStatusValue);
@@ -510,6 +511,12 @@ App.Components.AppointmentsModal = (function () {
 
         App.Utils.UI.initializeDateTimePicker($endDatetime);
         App.Utils.UI.setDateTimePickerValue($endDatetime, endDatetime);
+
+        $appointmentsModal
+            .find('.modal-message')
+            .removeClass('alert-danger')
+            .text('')
+            .addClass('d-none');
     }
 
     /**


### PR DESCRIPTION
With this fix I solved the following problem:

1) open the modal for creating a new appointment
2) click on save without entering any text in the mandatory user fields
3) click on cancel to exit the modal
4) reopen the modal for creating the appointment

The modal still shows the error message and the user fields are marked in red as invalid

![image](https://github.com/user-attachments/assets/aa4ece4f-cc05-4310-ab12-dc12a41ff44f)
