### PR TITLE
Fix headings in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php?/$1 [L]
 ```
 
-##Booking Wizard Won't Display Any Hours
+## Booking Wizard Won't Display Any Hours
 
 This issue comes when the customer is on the appointment book wizard but he is not seeing any available appointment hours and he cannot continue either. If your installation has this problem check the apache error log and open the browser's javascript console to find any issues. This is definetely a server issue and can only fixed by contacting your hosting company. It has to do with your server settings not letting Easy!Appointments run correctly. Normally you or the web hosting company will be able to find what needs to be changed in order to solve the issue.
 
@@ -34,12 +34,12 @@ Booking Wizard Displays "There are no available appointment hours for the select
 This is not actually an issue but it happened to a user and it was indeed confusing to resolve. A clean installation of E!A has some default settings such as the default working plan that contains some breaks too during the working days. This was set this way in order for you to see how can a working plan be like and set. So if you add a service that lasts for several hours (eg. 3~4 hours) then because of the default breaks new appointments will not fit in any empty time period of your calendar and thus the customer will not be able to book appointments with you. So if your services last for long you will need to change the working plan of your providers too so new appointments will fit into their schedule.
 
 
-##Installing E!A on Subdomain Won't Load Appointment Hours
+## Installing E!A on Subdomain Won't Load Appointment Hours
 
 If you want to install Easy!Appointments on a subdomain you will have to use the subdomain URL in your "configuration.php" file and not the initial URL directory. For example if you have the subdomain "http://book.mysite.com" where E!A resides and this subdomain is mapping on "http://mysite.com/book", you will have to set $base_url = 'http://book.mysite.com' in your "configuration.php" file, otherwise you will get a No 'Access-Control-Allow-Origin' error and you won't get any available appointment hours on frontend.
 
 
-##Change the gap of the available hours of the booking wizard to 60 minutes (or similar). 
+## Change the gap of the available hours of the booking wizard to 60 minutes (or similar). 
 
 The following link points to a common question that many users ask. The default gap between the available appointment hours is 15 minutes. In the following thread there is a file attached which will change this gap to 60 minutes. 
 


### PR DESCRIPTION
This PR fixes headings in the FAQ.md documentation. It adds space after the `##`, which causes the text to appear as second-level heading.