### PR TITLE
Suggestion: Improve calendar appointment title logic

### DIFF
--- a/assets/js/utils/calendar_default_view.js
+++ b/assets/js/utils/calendar_default_view.js
@@ -1201,7 +1201,11 @@ App.Utils.CalendarDefaultView = (function () {
 
                 // Add appointments to calendar.
                 response.appointments.forEach((appointment) => {
-                    const title = [appointment.service.name];
+                    let title = [];
+                    if(filterType != FILTER_TYPE_SERVICE){
+                        // If the filter type is not service, then we display the service name.
+                        title = [appointment.service.name];
+                    }
 
                     const customerInfo = [];
 


### PR DESCRIPTION
by selecting the filter on the service I think it is useless to repeat the name of the service on the appointment placeholder. all are referred to that service. This removal allows the user's name to be better displayed in case of numerous appointments.

## 🔧 Suggested Enhancement

This is a **suggested improvement** for the calendar default view functionality.

### Changes
- Added conditional logic for appointment title assignment based on filter type
- Improves user experience by showing service names only when filter type is not service

### Files Modified
- `assets/js/utils/calendar_default_view.js`

This is submitted as a **suggestion for consideration** rather than a required change.