### PR TITLE
Fix: handle undefined/null in sortedWorkingPlan; add test for calenda…

### DIFF
--- a/assets/js/utils/calendar_default_view.js
+++ b/assets/js/utils/calendar_default_view.js
@@ -1343,7 +1343,7 @@ App.Utils.CalendarDefaultView = (function () {
                     }
 
                     // Non-working day.
-                    if (sortedWorkingPlan[weekdayName] === null) {
+                    if (sortedWorkingPlan[weekdayName] == null) {
                         // Add a full day unavailability event.
                         unavailabilityEvent = {
                             title: lang('not_working'),

--- a/assets/js/utils/calendar_default_view.test.js
+++ b/assets/js/utils/calendar_default_view.test.js
@@ -1,0 +1,43 @@
+// calendar_default_view.test.js
+// Basic test for sortedWorkingPlan null/undefined handling
+
+const moment = require('moment');
+
+describe('CalendarDefaultView sortedWorkingPlan handling', () => {
+  it('should skip days with null or undefined working plan', () => {
+    // Mock data
+    const lang = (key) => key;
+    let calendarEventSource = [];
+    let calendarDate = moment('2025-10-15');
+    const weekdayName = 'Monday';
+    let sortedWorkingPlan = {
+      'Monday': null,
+      'Tuesday': undefined,
+      'Wednesday': { start: '09:00', end: '17:00' }
+    };
+
+    // Simulate the logic
+    Object.keys(sortedWorkingPlan).forEach((weekday) => {
+      if (sortedWorkingPlan[weekday] == null) {
+        const unavailabilityEvent = {
+          title: lang('not_working'),
+          start: calendarDate.clone().toDate(),
+          end: calendarDate.clone().add(1, 'day').toDate(),
+          allDay: false,
+          color: '#BEBEBE',
+          editable: false,
+          display: 'background',
+          className: 'fc-unavailability',
+        };
+        calendarEventSource.push(unavailabilityEvent);
+        calendarDate.add(1, 'day');
+        return;
+      }
+      // ...existing code for working days...
+    });
+
+    expect(calendarEventSource.length).toBe(2);
+    expect(calendarEventSource[0].title).toBe('not_working');
+    expect(calendarEventSource[1].title).toBe('not_working');
+  });
+});


### PR DESCRIPTION

Variable "sortedWorkingPlan" in /assets/js/utils/calendar_default_view.js contains undefined values  #1791
https://github.com/alextselegidis/easyappointments/issues/1791

With the value sortedWorkingPlan containing undefined values this means that a strict comparaison to null will be overlooked. Which will skip the continue and do a split on a non-existing start value.