### PR TITLE
Fix booking month date format on year change

### DIFF
--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -146,9 +146,9 @@ App.Pages.Booking = (function () {
 
                     const displayedMonthMoment = moment(
                         instance.currentYearElement.value +
-                            '-' +
-                            (Number(instance.monthsDropdownContainer.value) + 1) +
-                            '-01',
+                        '-' +
+                        String(Number(instance.monthsDropdownContainer.value) + 1).padStart(2, '0') +
+                        '-01',
                     );
 
                     const monthChangeStep = detectDatepickerMonthChangeStep(previousMoment, displayedMonthMoment);


### PR DESCRIPTION
The booking frontend was building a non-ISO date string (YYYY-M-01) when switching year,
which triggers Moment.js fallback parsing and leads to inconsistent calendar rendering
depending on browser and locale.

This change ensures the month is zero-padded so the date is always built as YYYY-MM-01.

* Note about minified file:
I did not regenerate booking.min.js for this patch.
The fix is applied to the source file (assets/js/pages/booking.js).
Minified assets can be rebuilt during CI or release.

* Test:

- Open booking page
- Switch year to 2026 and month to January
- No Moment warning, calendar renders consistently
