### PR TITLE
Add offline mode and ICS calendar export

### DIFF
--- a/application/language/english/translations_lang.php
+++ b/application/language/english/translations_lang.php
@@ -37,6 +37,7 @@ $lang['reason'] = 'Reason';
 $lang['appointment_removed_from_schedule'] = 'The following appointment was removed from the company\'s schedule.';
 $lang['appointment_details_was_sent_to_you'] = 'An email with the appointment details has been sent to you.';
 $lang['add_to_google_calendar'] = 'Add to Google Calendar';
+$lang['download_ics_file'] = 'Download Calendar File (.ics)';
 $lang['appointment_booked'] = 'Your appointment has been successfully booked';
 $lang['thank_you_for_appointment'] = 'Thank you for arranging an appointment with us. Below you can see the appointment details. Make changes by clicking the appointment link.';
 $lang['appointment_details_title'] = 'Appointment Details';

--- a/application/language/french/translations_lang.php
+++ b/application/language/french/translations_lang.php
@@ -37,6 +37,7 @@ $lang['reason'] = 'Motif';
 $lang['appointment_removed_from_schedule'] = 'Le rendez-vous suivant a été supprimé de l’agenda.';
 $lang['appointment_details_was_sent_to_you'] = 'Un email reprenant les détails de votre rendez-vous vient de vous être envoyé.';
 $lang['add_to_google_calendar'] = 'Ajouter à Google Calendar';
+$lang['download_ics_file'] = 'Télécharger le fichier calendrier (.ics)';
 $lang['appointment_booked'] = 'Votre rendez-vous a été confirmé avec succès.';
 $lang['thank_you_for_appointment'] = 'Merci de votre prise de rendez-vous avec nous. Vous trouvez ci-joint les détails de votre rendez-vous. Si nécessaire, faites les changements souhaités en cliquant sur le lien du rendez-vous.';
 $lang['appointment_details_title'] = 'Détails du rendez-vous';

--- a/application/views/layouts/booking_layout.php
+++ b/application/views/layouts/booking_layout.php
@@ -90,12 +90,6 @@
 <?php component('js_vars_script'); ?>
 <?php component('js_lang_script'); ?>
 
-<?php component('google_analytics_script', ['google_analytics_code' => vars('google_analytics_code')]); ?>
-<?php component('matomo_analytics_script', [
-    'matomo_analytics_url' => vars('matomo_analytics_url'),
-    'matomo_analytics_site_id' => vars('matomo_analytics_site_id'),
-]); ?>
-
 <?php slot('scripts'); ?>
 
 </body>

--- a/application/views/pages/about.php
+++ b/application/views/pages/about.php
@@ -34,61 +34,6 @@
         </div>
 
         <h4 class="fw-light text-black-50 mb-3">
-            <?= lang('support') ?>
-        </h4>
-
-        <p>
-            <?= lang('about_app_support') ?>
-        </p>
-
-        <div class="row mb-5">
-            <div class="col-lg-6 mb-3">
-                <a class="btn btn-outline-secondary d-block" href="https://easyappointments.org" target="_blank">
-                    <i class="fas fa-external-link-alt me-2"></i>
-                    <?= lang('official_website') ?>
-                </a>
-            </div>
-
-            <div class="col-lg-6 mb-3">
-                <a class="btn btn-outline-secondary d-block"
-                   href="https://groups.google.com/forum/#!forum/easy-appointments" target="_blank">
-                    <i class="fas fa-external-link-alt me-2"></i>
-                    <?= lang('support_group') ?>
-                </a>
-            </div>
-
-            <div class="col-lg-6 mb-3">
-                <a class="btn btn-outline-secondary d-block"
-                   href="https://github.com/alextselegidis/easyappointments/issues" target="_blank">
-                    <i class="fas fa-external-link-alt me-2"></i>
-                    <?= lang('project_issues') ?>
-                </a>
-            </div>
-
-            <div class="col-lg-6 mb-3">
-                <a class="btn btn-outline-secondary d-block" href="https://facebook.com/easyappts" target="_blank">
-                    <i class="fas fa-external-link-alt me-2"></i>
-                    Facebook
-                </a>
-            </div>
-
-            <div class="col-lg-6 mb-3">
-                <a class="btn btn-outline-secondary d-block" href="https://x.com/easyappts" target="_blank">
-                    <i class="fas fa-external-link-alt me-2"></i>
-                    X.com
-                </a>
-            </div>
-
-            <div class="col-lg-6 mb-3">
-                <a class="btn btn-outline-secondary d-block" href="https://easyappointments.org/get-a-free-quote"
-                   target="_blank">
-                    <i class="fas fa-external-link-alt me-2"></i>
-                    Customize E!A
-                </a>
-            </div>
-        </div>
-
-        <h4 class="fw-light text-black-50 mb-3">
             <?= lang('license') ?>
         </h4>
 
@@ -97,11 +42,10 @@
         </p>
 
         <div class="mb-5">
-            <a class="btn btn-outline-secondary d-block w-50 m-auto" href="https://www.gnu.org/licenses/gpl-3.0.en.html"
-               target="_blank">
-                <i class="fas fa-external-link-alt me-2"></i>
+            <span class="btn btn-outline-secondary d-block w-50 m-auto disabled">
+                <i class="fas fa-balance-scale me-2"></i>
                 GPL-3.0
-            </a>
+            </span>
         </div>
     </div>
 </div>

--- a/application/views/pages/booking_cancellation.php
+++ b/application/views/pages/booking_cancellation.php
@@ -21,12 +21,3 @@
 
 <?php end_section('content'); ?>
 
-<?php section('scripts'); ?>
-
-<?php component('google_analytics_script', ['google_analytics_code' => vars('google_analytics_code')]); ?>
-<?php component('matomo_analytics_script', [
-    'matomo_analytics_url' => vars('matomo_analytics_url'),
-    'matomo_analytics_site_id' => vars('matomo_analytics_site_id'),
-]); ?>
-<?php end_section('scripts'); ?>
-

--- a/application/views/pages/booking_confirmation.php
+++ b/application/views/pages/booking_confirmation.php
@@ -24,20 +24,10 @@
         <?= lang('go_to_booking_page') ?>
     </a>
 
-    <a href="<?= vars('add_to_google_url') ?>" id="add-to-google-calendar" class="btn btn-primary" target="_blank">
-        <i class="fas fa-plus me-2"></i>
-        <?= lang('add_to_google_calendar') ?>
+    <a href="<?= site_url('booking_confirmation/ics/' . vars('appointment_hash')) ?>" id="download-ics" class="btn btn-primary">
+        <i class="fas fa-download me-2"></i>
+        <?= lang('download_ics_file') ?>
     </a>
 </div>
 
 <?php end_section('content'); ?>
-
-<?php section('scripts'); ?>
-
-<?php component('google_analytics_script', ['google_analytics_code' => vars('google_analytics_code')]); ?>
-<?php component('matomo_analytics_script', [
-    'matomo_analytics_url' => vars('matomo_analytics_url'),
-    'matomo_analytics_site_id' => vars('matomo_analytics_site_id'),
-]); ?>
-
-<?php end_section('scripts'); ?>

--- a/application/views/pages/booking_message.php
+++ b/application/views/pages/booking_message.php
@@ -14,13 +14,3 @@
 
 <?php end_section('content'); ?>
 
-<?php section('scripts'); ?>
-
-<?php component('google_analytics_script', ['google_analytics_code' => vars('google_analytics_code')]); ?>
-<?php component('matomo_analytics_script', [
-    'matomo_analytics_url' => vars('matomo_analytics_url'),
-    'matomo_analytics_site_id' => vars('matomo_analytics_site_id'),
-]); ?>
-
-<?php end_section('scripts'); ?>
-


### PR DESCRIPTION
- Replace "Add to Google Calendar" button with ICS file download
- Remove Google Analytics and Matomo tracking scripts from all booking pages
- Remove external links from the about page for offline usage
- Add new endpoint /booking_confirmation/ics/{hash} for ICS download
- Add translations for download button (EN/FR)
- Add security headers and input validation for ICS endpoint