### PR TITLE
Making calendar views more adaptive to browser window size

### DIFF
--- a/assets/js/utils/calendar_default_view.js
+++ b/assets/js/utils/calendar_default_view.js
@@ -56,13 +56,13 @@ App.Utils.CalendarDefaultView = (function () {
     /**
      * Get the calendar height based on window size.
      *
-     * @returns {number} Calendar height in pixels (minimum 780px).
+     * @returns {number} Calendar height in pixels (minimum 500px).
      */
     function getCalendarHeight() {
         const offset = $footer.outerHeight() +
             $header.outerHeight() +
             $calendarToolbar.outerHeight() +
-            30;
+            35;
         const height = window.innerHeight - offset;
 
         return Math.max(height, 500);

--- a/assets/js/utils/calendar_table_view.js
+++ b/assets/js/utils/calendar_table_view.js
@@ -55,7 +55,7 @@ App.Utils.CalendarTableView = (function () {
     /**
      * Get the calendar height based on window size.
      *
-     * @returns {number} Calendar height in pixels (minimum 800px).
+     * @returns {number} Calendar height in pixels (minimum 400px).
      */
     function getCalendarHeight() {
         const offset = $footer.outerHeight() +


### PR DESCRIPTION
This makes calendar views more adaptive to browser window size and its changes. Especially table view had no adaption to browser window changes.

Before this PR, unless you have maximized browser window or very large screen, you would get two vertical scroll bars, one for browser window and one for calendar element.
With this PR, there is no vertical scroll bar for browser window unless window height is below limit, which is now smaller than before.