### PR TITLE
Re-Optimize backend query during booking process

### DIFF
--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -432,8 +432,6 @@ App.Pages.Booking = (function () {
                     $selectService.val(),
                     todayMoment.format('YYYY-MM-DD'),
                 );
-
-                App.Http.Booking.getAvailableHours(todayMoment.format('YYYY-MM-DD'));
             }
 
             // If we are on the 2nd tab then the user should have an appointment hour selected.


### PR DESCRIPTION
After commit [9166e16](https://github.com/alextselegidis/easyappointments/commit/9166e16e4ed7ec1abe14953261f2d72090f6485c) I have experienced problems when advancing from booking step 1 to step 2.

Occasionally, I get no available hours even if it is certain that there are available hours.
![Näyttökuva 2026-02-25 074306](https://github.com/user-attachments/assets/8b28c4d5-063f-4e75-8dd0-4fc675dec37a)

If I click on the selected day (in this case 27), getAvailableHours() is called (again)  and available hours are displayed.
![Näyttökuva 2026-02-25 074331](https://github.com/user-attachments/assets/9bf24ff0-c074-4897-998f-594b04f3cc30)

It appears that getAvailableHours() is called twice when advancing from step 1 to step 2.
![Näyttökuva 2026-02-25 074246](https://github.com/user-attachments/assets/9c6a9d30-9bb9-4a91-973d-810a8b58f251)
For one call time seems abnormally long, and size is smaller. As this takes longer time, it finishes last and as the size is smaller, it is probably missing available hours.

With this PR, getAvailableHours() is called only once when advancing from step 1 to step 2, and time and size seem to be  normal.
![Näyttökuva 2026-02-25 074417](https://github.com/user-attachments/assets/9dfc4b2c-e257-49b9-98c6-64d1d4f78f75)

As far as I have tested, there are no problems with available hours any more with this PR


