### PR TITLE
fix: improve CalDAV sync robustness with namespace URI and error handling

### DIFF
--- a/application/controllers/Caldav.php
+++ b/application/controllers/Caldav.php
@@ -242,58 +242,68 @@ class Caldav extends EA_Controller
         $CI->appointments_model->delete_caldav_recurring_events($start_date_time, $end_date_time);
 
         foreach ($caldav_events as $caldav_event) {
-            if ($caldav_event['status'] === 'CANCELLED') {
-                continue;
-            }
+            try {
+                if ($caldav_event['status'] === 'CANCELLED') {
+                    continue;
+                }
 
-            if ($caldav_event['start_datetime'] === $caldav_event['end_datetime']) {
-                continue; // Cannot sync events with the same start and end date time value
-            }
+                if ($caldav_event['start_datetime'] === $caldav_event['end_datetime']) {
+                    continue; // Cannot sync events with the same start and end date time value
+                }
 
-            $appointment_results = $CI->appointments_model->get(['id_caldav_calendar' => $caldav_event['id']]);
+                $appointment_results = $CI->appointments_model->get(['id_caldav_calendar' => $caldav_event['id']]);
 
-            if (!empty($appointment_results)) {
-                continue;
-            }
+                if (!empty($appointment_results)) {
+                    continue;
+                }
 
-            $unavailability_results = $CI->unavailabilities_model->get([
-                'id_caldav_calendar' => $caldav_event['id'],
-            ]);
+                $unavailability_results = $CI->unavailabilities_model->get([
+                    'id_caldav_calendar' => $caldav_event['id'],
+                ]);
 
-            if (!empty($unavailability_results)) {
-                continue;
-            }
+                if (!empty($unavailability_results)) {
+                    continue;
+                }
 
-            $matching_unavailability = $CI->unavailabilities_model
-                ->query()
-                ->where([
+                $matching_unavailability = $CI->unavailabilities_model
+                    ->query()
+                    ->where([
+                        'start_datetime' => $caldav_event['start_datetime'],
+                        'end_datetime' => $caldav_event['end_datetime'],
+                        'notes' => $caldav_event['summary'] . ' ' . $caldav_event['description'],
+                        'id_users_provider' => $provider_id,
+                    ])
+                    ->get()
+                    ->row_array();
+
+                if ($matching_unavailability) {
+                    // Update the ID of the matching unavailability record.
+                    $matching_unavailability['id_caldav_calendar'] = $caldav_event['id'];
+                    $CI->unavailabilities_model->save($matching_unavailability);
+                    continue;
+                }
+
+                // Record doesn't exist in the Easy!Appointments, so add the event now.
+
+                $local_event = [
                     'start_datetime' => $caldav_event['start_datetime'],
                     'end_datetime' => $caldav_event['end_datetime'],
+                    'location' => $caldav_event['location'],
                     'notes' => $caldav_event['summary'] . ' ' . $caldav_event['description'],
                     'id_users_provider' => $provider_id,
-                ])
-                ->get()
-                ->row_array();
+                    'id_caldav_calendar' => $caldav_event['id'],
+                ];
 
-            if ($matching_unavailability) {
-                // Update the ID of the matching unavailability record.
-                $matching_unavailability['id_caldav_calendar'] = $caldav_event['id'];
-                $CI->unavailabilities_model->save($matching_unavailability);
-                continue;
+                $CI->unavailabilities_model->save($local_event);
+            } catch (Throwable $e) {
+                log_message(
+                    'error',
+                    'CalDAV sync: failed to import event '
+                        . ($caldav_event['id'] ?? 'unknown')
+                        . ': '
+                        . $e->getMessage(),
+                );
             }
-
-            // Record doesn't exist in the Easy!Appointments, so add the event now.
-
-            $local_event = [
-                'start_datetime' => $caldav_event['start_datetime'],
-                'end_datetime' => $caldav_event['end_datetime'],
-                'location' => $caldav_event['location'],
-                'notes' => $caldav_event['summary'] . ' ' . $caldav_event['description'],
-                'id_users_provider' => $provider_id,
-                'id_caldav_calendar' => $caldav_event['id'],
-            ];
-
-            $CI->unavailabilities_model->save($local_event);
         }
 
         json_response([

--- a/application/libraries/Caldav_sync.php
+++ b/application/libraries/Caldav_sync.php
@@ -246,31 +246,18 @@ class Caldav_sync
         $responses = $xml_namespace ? $xml->children($xml_namespace, true) : $xml->children();
 
         foreach ($responses as $response) {
-            // CalDAV namespace can be prefixed as 'cal', 'C', or 'c', try common prefixes used by different CalDAV servers
+            // Use the CalDAV namespace URI to find calendar-data elements regardless of
+            // which prefix the server chose (e.g. 'cal', 'C', 'c', or any other valid prefix).
             $prop = $response->propstat->prop;
 
             $ics_contents = '';
 
-            if (count($prop->children('cal', true)) > 0) {
-                $ics_contents = (string) $prop->children('cal', true);
-            } elseif (count($prop->children('C', true)) > 0) {
-                $caldav_children = $prop->children('C', true);
+            $caldav_children = $prop->children('urn:ietf:params:xml:ns:caldav');
 
-                // Get calendar-data element
-                foreach ($caldav_children as $child) {
-                    if ($child->getName() == 'calendar-data') {
-                        $ics_contents = (string) $child;
-                        break;
-                    }
-                }
-            } elseif (count($prop->children('c', true)) > 0) {
-                $caldav_children = $prop->children('c', true);
-
-                foreach ($caldav_children as $child) {
-                    if ($child->getName() == 'calendar-data') {
-                        $ics_contents = (string) $child;
-                        break;
-                    }
+            foreach ($caldav_children as $child) {
+                if ($child->getName() === 'calendar-data') {
+                    $ics_contents = (string) $child;
+                    break;
                 }
             }
 


### PR DESCRIPTION
## Summary

Two fixes to improve CalDAV sync reliability:

- **Use namespace URI instead of prefix for XML parsing** — `parse_xml_events()` previously tried a hardcoded list of prefixes (`'cal'`, `'C'`, `'c'`) to find `calendar-data` elements. XML namespace prefixes are arbitrary — only the URI is guaranteed. This replaces the prefix-guessing with `->children('urn:ietf:params:xml:ns:caldav')` which works with all compliant CalDAV servers regardless of their chosen prefix. Improves on the approach in #1840.

- **Wrap individual event imports in try/catch** — In `Caldav::sync()`, a single event failing validation (e.g. the minimum duration check in `Unavailabilities_model`) would abort the entire sync. Now each event is processed independently — failures are logged and the remaining events continue syncing.

## Context

Discovered while syncing with Fastmail's CalDAV server, which uses `xmlns:c="urn:ietf:params:xml:ns:caldav"`. The `'c'` prefix was added in #1840 but the underlying issue remains for any server using a prefix not in the hardcoded list. The namespace URI approach is the correct solution per the XML specification.

The error handling gap was discovered when a recurring calendar event expanded to a sub-5-minute instance, triggering `EVENT_MINIMUM_DURATION` validation and crashing the sync for all remaining events.

## Test plan

- [ ] CalDAV sync with Fastmail (prefix `c`)
- [ ] CalDAV sync with other providers (Radicale uses `C`, some use `cal`)
- [ ] Sync a calendar containing events shorter than `EVENT_MINIMUM_DURATION` — they should be skipped with a log entry, not crash the sync
- [ ] Verify skipped events are logged in `storage/logs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)