### PR TITLE
fix(google_sync): paginate listEvents to fetch all calendar events

### DIFF
--- a/application/libraries/Google_sync.php
+++ b/application/libraries/Google_sync.php
@@ -384,7 +384,30 @@ class Google_sync
             'singleEvents' => true,
         ];
 
-        return $this->service->events->listEvents($google_calendar, $params);
+        $events = $this->service->events->listEvents($google_calendar, $params);
+        $allItems = $events->getItems();
+
+        // Iterate through additional pages because Google Calendar API listEvents
+        // returns at most 250 events per page by default. Without this loop,
+        // calendars with more than 250 events in the sync window silently lose
+        // events from page 2 onwards, which prevents them from being reflected
+        // as unavailabilities in Easy!Appointments.
+        // A safety bound of 50 pages (≈ 12500 events) protects against unexpected
+        // behaviour such as a circular nextPageToken.
+        $maxPages = 50;
+        $page = 0;
+        $pageToken = $events->getNextPageToken();
+        while (!empty($pageToken) && $page < $maxPages) {
+            $page++;
+            $params['pageToken'] = $pageToken;
+            $next = $this->service->events->listEvents($google_calendar, $params);
+            $allItems = array_merge($allItems, $next->getItems());
+            $pageToken = $next->getNextPageToken();
+        }
+
+        $events->setItems($allItems);
+
+        return $events;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fix a silent data-loss bug in `Google_sync::get_sync_events()`. Calendars containing more than 250 events in the configured sync window lose events from page 2 onwards because `listEvents` is called only once and `nextPageToken` is never followed. Affected events are never imported into the local `appointments` table as unavailabilities, so customers can still book appointments at those times.

## Reproduction

1. Connect a Google Calendar to a provider in Easy!Appointments.
2. Ensure the connected calendar has more than 250 events between `today - sync_past_days` and `today + sync_future_days` (e.g. recurring meetings expanded by `singleEvents=true`).
3. Trigger a sync (admin UI or `php index.php google sync <provider_id>`).
4. Observe that some events from the connected calendar are not present in `appointments` (`is_unavailability = 1`).
5. The Booking page exposes those missing time slots as bookable.

This was reported as a production bug at plus-b.jp on 2026-04-27. The provider's calendar had ~600 events in a 120-day window. A direct Google Calendar API call with the EA provider's access token confirmed:

- `listEvents(...)` returned `items.length == 250` and a non-empty `nextPageToken`.
- Specific events on page 2+ were absent from `ea_appointments` even after a successful sync.

## Fix

In `application/libraries/Google_sync.php::get_sync_events()`, iterate through additional pages while `nextPageToken` is non-empty and merge the results back into the original `Events` object via `setItems()`.

A safety bound of 50 pages (≈12500 events) protects against pathological responses (e.g. circular `nextPageToken`). When the bound is hit, the function returns the partial result rather than looping unbounded; this matches the existing failure mode (returning whatever happens to come back) but with deterministic behaviour.

The function signature, return type, and caller-visible behaviour are unchanged.

## Verification

- `php -l application/libraries/Google_sync.php` → no syntax errors.
- Tested in a downstream deployment with a calendar of >250 events: all events are now imported as unavailabilities and the previously missing slots are correctly marked unavailable on the Booking page.

## Notes

- Depends on the existing `Google\Service\Calendar\Events::setItems()` mutator, which is part of the public API of the Google PHP client used by Easy!Appointments.
- No changes to schema, configuration, or other libraries.