### PR TITLE
Optional Service & Category Sorting for Booking Flow

### DIFF
--- a/application/controllers/General_settings.php
+++ b/application/controllers/General_settings.php
@@ -97,6 +97,7 @@ class General_settings extends EA_Controller
         'date_format',
         'time_format',
         'first_weekday',
+        'sort_services_and_categories',
         'require_phone_number',
         'display_cookie_notice',
         'cookie_notice_content',

--- a/application/controllers/Providers.php
+++ b/application/controllers/Providers.php
@@ -105,7 +105,8 @@ class Providers extends EA_Controller
 
         $role_slug = session('role_slug');
 
-        $services = $this->services_model->get();
+        $services_order = setting('sort_services_and_categories', '0') ? 'position ASC, update_datetime DESC' : null;
+        $services = $this->services_model->get(null, null, null, $services_order);
 
         foreach ($services as &$service) {
             $this->services_model->only($service, $this->allowed_service_fields);
@@ -131,7 +132,7 @@ class Providers extends EA_Controller
             'user_display_name' => $this->accounts->get_user_display_name($user_id),
             'grouped_timezones' => $this->timezones->to_grouped_array(),
             'privileges' => $this->roles_model->get_permissions_by_slug($role_slug),
-            'services' => $this->services_model->get(),
+            'services' => $services,
         ]);
 
         $this->load->view('pages/providers');

--- a/application/controllers/Service_categories.php
+++ b/application/controllers/Service_categories.php
@@ -68,6 +68,7 @@ class Service_categories extends EA_Controller
         script_vars([
             'user_id' => $user_id,
             'role_slug' => $role_slug,
+            'custom_sorting_enabled' => (bool) setting('sort_services_and_categories', '0'),
         ]);
 
         html_vars([
@@ -100,7 +101,10 @@ class Service_categories extends EA_Controller
 
             $keyword = request('keyword', '');
 
-            $order_by = request('order_by', 'update_datetime DESC');
+            $order_by = request(
+                'order_by',
+                setting('sort_services_and_categories', '0') ? 'position ASC, update_datetime DESC' : 'update_datetime DESC',
+            );
 
             $limit = request('limit', 1000);
 
@@ -251,6 +255,40 @@ class Service_categories extends EA_Controller
             json_response([
                 'success' => true,
             ]);
+        } catch (Throwable $e) {
+            json_exception($e);
+        }
+    }
+
+    /**
+     * Move a service category up or down in the custom order.
+     */
+    public function move_position(): void
+    {
+        try {
+            method('post');
+
+            if (cannot('edit', PRIV_SERVICES)) {
+                abort(403, 'Forbidden');
+            }
+
+            if (!setting('sort_services_and_categories', '0')) {
+                abort(403, 'Service category sorting is disabled.');
+            }
+
+            check('service_category_id', 'numeric');
+            check('direction', 'string');
+
+            $service_category_id = (int) request('service_category_id');
+            $direction = request('direction');
+
+            if (!in_array($direction, ['up', 'down'], true)) {
+                throw new InvalidArgumentException('Invalid sorting direction.');
+            }
+
+            $this->service_categories_model->move_position($service_category_id, $direction);
+
+            json_response(['success' => true]);
         } catch (Throwable $e) {
             json_exception($e);
         }

--- a/application/controllers/Services.php
+++ b/application/controllers/Services.php
@@ -88,6 +88,7 @@ class Services extends EA_Controller
             'role_slug' => $role_slug,
             'event_minimum_duration' => EVENT_MINIMUM_DURATION,
             'providers' => filter_sensitive_users_data($providers),
+            'custom_sorting_enabled' => (bool) setting('sort_services_and_categories', '0'),
         ]);
 
         html_vars([
@@ -121,7 +122,10 @@ class Services extends EA_Controller
 
             $keyword = request('keyword', '');
 
-            $order_by = request('order_by', 'update_datetime DESC');
+            $order_by = request(
+                'order_by',
+                setting('sort_services_and_categories', '0') ? 'position ASC, update_datetime DESC' : 'update_datetime DESC',
+            );
 
             $limit = request('limit', 1000);
 
@@ -269,6 +273,40 @@ class Services extends EA_Controller
             json_response([
                 'success' => true,
             ]);
+        } catch (Throwable $e) {
+            json_exception($e);
+        }
+    }
+
+    /**
+     * Move a service up or down in the custom order.
+     */
+    public function move_position(): void
+    {
+        try {
+            method('post');
+
+            if (cannot('edit', PRIV_SERVICES)) {
+                abort(403, 'Forbidden');
+            }
+
+            if (!setting('sort_services_and_categories', '0')) {
+                abort(403, 'Service sorting is disabled.');
+            }
+
+            check('service_id', 'numeric');
+            check('direction', 'string');
+
+            $service_id = (int) request('service_id');
+            $direction = request('direction');
+
+            if (!in_array($direction, ['up', 'down'], true)) {
+                throw new InvalidArgumentException('Invalid sorting direction.');
+            }
+
+            $this->services_model->move_position($service_id, $direction);
+
+            json_response(['success' => true]);
         } catch (Throwable $e) {
             json_exception($e);
         }

--- a/application/language/albanian/translations_lang.php
+++ b/application/language/albanian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Ofrojmë shërbime të plota për softuer të vet�
 $lang['go_premium'] = 'Kaloni në Premium';
 $lang['notify_users_on_create_question'] = 'Dëshironi të njoftoni klientin për këtë takim të ri?';
 $lang['notify_users_on_delete_question'] = 'Dëshironi të njoftoni klientin për anulimin e takimit?';
+
+$lang['sort_services_and_categories'] = 'Aktivizo renditjen e shërbimeve dhe kategorive';
+$lang['sort_services_and_categories_hint'] = 'Trego kontrollet e renditjes admin dhe përdor rendin e personalizuar në rezervim.';
+$lang['move_up'] = 'Lëviz lart';
+$lang['move_down'] = 'Lëviz poshtë';
+
 // End

--- a/application/language/arabic/translations_lang.php
+++ b/application/language/arabic/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'نقدم خدمات شاملة للبرمجيات 
 $lang['go_premium'] = 'احصل على Premium';
 $lang['notify_users_on_create_question'] = 'هل ترغب في إبلاغ العميل بهذا الموعد الجديد؟';
 $lang['notify_users_on_delete_question'] = 'هل ترغب في إبلاغ العميل بإلغاء الموعد؟';
+
+$lang['sort_services_and_categories'] = 'تفعيل ترتيب الخدمات والفئات';
+$lang['sort_services_and_categories_hint'] = 'إظهار عناصر التحكم في الترتيب للمسؤول واستخدام الترتيب المخصص في الحجز.';
+$lang['move_up'] = 'تحريك لأعلى';
+$lang['move_down'] = 'تحريك لأسفل';
+
 // End

--- a/application/language/bosnian/translations_lang.php
+++ b/application/language/bosnian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Nudimo kompletne usluge za samostalno hostovan sof
 $lang['go_premium'] = 'Postanite Premium';
 $lang['notify_users_on_create_question'] = 'Želite li obavijestiti klijenta o ovom novom terminu?';
 $lang['notify_users_on_delete_question'] = 'Želite li obavijestiti klijenta o otkazivanju termina?';
+
+$lang['sort_services_and_categories'] = 'Omogući sortiranje usluga i kategorija';
+$lang['sort_services_and_categories_hint'] = 'Prikaži kontrole sortiranja za admina i koristi prilagođeni redoslijed pri rezervaciji.';
+$lang['move_up'] = 'Pomjeri gore';
+$lang['move_down'] = 'Pomjeri dolje';
+
 // End

--- a/application/language/bulgarian/translations_lang.php
+++ b/application/language/bulgarian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Предлагаме цялостни услуги
 $lang['go_premium'] = 'Към Premium';
 $lang['notify_users_on_create_question'] = 'Желаете ли да уведомите клиента за тази нова среща?';
 $lang['notify_users_on_delete_question'] = 'Желаете ли да уведомите клиента за отмяната на срещата?';
+
+$lang['sort_services_and_categories'] = 'Активиране на сортиране на услуги и категории';
+$lang['sort_services_and_categories_hint'] = 'Показване на контроли за сортиране за администратора и използване на персонализиран ред при резервация.';
+$lang['move_up'] = 'Нагоре';
+$lang['move_down'] = 'Надолу';
+
 // End

--- a/application/language/catalan/translations_lang.php
+++ b/application/language/catalan/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Oferim serveis d\'extrem a extrem per a programari
 $lang['go_premium'] = 'Passa\'t a Premium';
 $lang['notify_users_on_create_question'] = 'Voleu notificar el client sobre aquesta nova cita?';
 $lang['notify_users_on_delete_question'] = 'Voleu notificar el client sobre la cancel·lació de la cita?';
+
+$lang['sort_services_and_categories'] = 'Activar l\'ordenació de serveis i categories';
+$lang['sort_services_and_categories_hint'] = 'Mostrar els controls d\'ordenació admin i utilitzar l\'ordre personalitzat a la reserva.';
+$lang['move_up'] = 'Pujar';
+$lang['move_down'] = 'Baixar';
+
 // End

--- a/application/language/chinese/translations_lang.php
+++ b/application/language/chinese/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = '我们为自托管软件提供端到端服务，�
 $lang['go_premium'] = '升级 Premium';
 $lang['notify_users_on_create_question'] = '您想通知客户这个新预约吗？';
 $lang['notify_users_on_delete_question'] = '您想通知客户预约取消吗？';
+
+$lang['sort_services_and_categories'] = '启用服务和分类排序';
+$lang['sort_services_and_categories_hint'] = '显示管理排序控件并在预订中使用自定义顺序。';
+$lang['move_up'] = '上移';
+$lang['move_down'] = '下移';
+
 // End

--- a/application/language/croatian/translations_lang.php
+++ b/application/language/croatian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Nudimo cjelovite usluge za samostalno hostirani so
 $lang['go_premium'] = 'Postanite Premium';
 $lang['notify_users_on_create_question'] = 'Želite li obavijestiti klijenta o ovom novom terminu?';
 $lang['notify_users_on_delete_question'] = 'Želite li obavijestiti klijenta o otkazivanju termina?';
+
+$lang['sort_services_and_categories'] = 'Omogući sortiranje usluga i kategorija';
+$lang['sort_services_and_categories_hint'] = 'Prikaži kontrole sortiranja za admina i koristi prilagođeni redoslijed pri rezervaciji.';
+$lang['move_up'] = 'Pomakni gore';
+$lang['move_down'] = 'Pomakni dolje';
+
 // End

--- a/application/language/czech/translations_lang.php
+++ b/application/language/czech/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Nabízíme komplexní služby pro self-hosted soft
 $lang['go_premium'] = 'Přejít na Premium';
 $lang['notify_users_on_create_question'] = 'Chcete zákazníka informovat o této nové schůzce?';
 $lang['notify_users_on_delete_question'] = 'Chcete zákazníka informovat o zrušení schůzky?';
+
+$lang['sort_services_and_categories'] = 'Povolit řazení služeb a kategorií';
+$lang['sort_services_and_categories_hint'] = 'Zobrazit ovládací prvky řazení pro admina a použít vlastní pořadí při rezervaci.';
+$lang['move_up'] = 'Posunout nahoru';
+$lang['move_down'] = 'Posunout dolů';
+
 // End

--- a/application/language/danish/translations_lang.php
+++ b/application/language/danish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Vi tilbyder helhedstjenester for selvhostet softwa
 $lang['go_premium'] = 'Bliv Premium';
 $lang['notify_users_on_create_question'] = 'Vil du give kunden besked om denne nye aftale?';
 $lang['notify_users_on_delete_question'] = 'Vil du give kunden besked om aflysningen af aftalen?';
+
+$lang['sort_services_and_categories'] = 'Aktiver sortering af tjenester og kategorier';
+$lang['sort_services_and_categories_hint'] = 'Vis admin-sorteringskontroller og brug tilpasset rækkefølge ved booking.';
+$lang['move_up'] = 'Flyt op';
+$lang['move_down'] = 'Flyt ned';
+
 // End

--- a/application/language/dutch/translations_lang.php
+++ b/application/language/dutch/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Wij bieden uitgebreide diensten voor zelf gehoste 
 $lang['go_premium'] = 'Ga Premium';
 $lang['notify_users_on_create_question'] = 'Wilt u de klant op de hoogte stellen van deze nieuwe afspraak?';
 $lang['notify_users_on_delete_question'] = 'Wilt u de klant op de hoogte stellen van de annulering van de afspraak?';
+
+$lang['sort_services_and_categories'] = 'Sorteren van diensten en categorieën inschakelen';
+$lang['sort_services_and_categories_hint'] = 'Admin-sorteerbediening weergeven en aangepaste volgorde gebruiken bij boeken.';
+$lang['move_up'] = 'Omhoog';
+$lang['move_down'] = 'Omlaag';
+
 // End

--- a/application/language/english/translations_lang.php
+++ b/application/language/english/translations_lang.php
@@ -574,4 +574,8 @@ $lang['about_app_premium'] = 'We offer end-to-end services for self-hosted softw
 $lang['go_premium'] = 'Go Premium';
 $lang['notify_users_on_create_question'] = 'Would you like to send out a notification about this change?';
 $lang['notify_users_on_delete_question'] = 'Would you like to send out a notification about this change?';
+$lang['sort_services_and_categories'] = 'Enable Service & Category Sorting';
+$lang['sort_services_and_categories_hint'] = 'Show admin sorting controls and use the custom order in booking.';
+$lang['move_up'] = 'Move Up';
+$lang['move_down'] = 'Move Down';
 // End

--- a/application/language/estonian/translations_lang.php
+++ b/application/language/estonian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Pakume täisteenust ise majutatud tarkvarale, seal
 $lang['go_premium'] = 'Go Premium';
 $lang['notify_users_on_create_question'] = 'Kas soovite klienti sellest uuest kohtumisest teavitada?';
 $lang['notify_users_on_delete_question'] = 'Kas soovite klienti kohtumise tühistamisest teavitada?';
+
+$lang['sort_services_and_categories'] = 'Luba teenuste ja kategooriate sortimine';
+$lang['sort_services_and_categories_hint'] = 'Kuva administraatori sortimise juhtelemendid ja kasuta broneerimisel kohandatud järjestust.';
+$lang['move_up'] = 'Liiguta üles';
+$lang['move_down'] = 'Liiguta alla';
+
 // End

--- a/application/language/finnish/translations_lang.php
+++ b/application/language/finnish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Tarjoamme kokonaispalveluja itse ylläpidetylle oh
 $lang['go_premium'] = 'Go Premium';
 $lang['notify_users_on_create_question'] = 'Haluatko ilmoittaa asiakkaalle tästä uudesta ajanvarauksesta?';
 $lang['notify_users_on_delete_question'] = 'Haluatko ilmoittaa asiakkaalle ajanvarauksen peruutuksesta?';
+
+$lang['sort_services_and_categories'] = 'Ota käyttöön palveluiden ja kategorioiden lajittelu';
+$lang['sort_services_and_categories_hint'] = 'Näytä ylläpidon lajittelusäätimet ja käytä mukautettua järjestystä varauksessa.';
+$lang['move_up'] = 'Siirrä ylös';
+$lang['move_down'] = 'Siirrä alas';
+
 // End

--- a/application/language/french/translations_lang.php
+++ b/application/language/french/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Nous proposons des services complets pour les logi
 $lang['go_premium'] = 'Passer à Premium';
 $lang['notify_users_on_create_question'] = 'Souhaitez-vous informer le client de ce nouveau rendez-vous ?';
 $lang['notify_users_on_delete_question'] = 'Souhaitez-vous informer le client de l\'annulation du rendez-vous ?';
+
+$lang['sort_services_and_categories'] = 'Activer le tri des services et catégories';
+$lang['sort_services_and_categories_hint'] = 'Afficher les contrôles de tri admin et utiliser l\'ordre personnalisé dans la réservation.';
+$lang['move_up'] = 'Monter';
+$lang['move_down'] = 'Descendre';
+
 // End

--- a/application/language/german/translations_lang.php
+++ b/application/language/german/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Wir bieten umfassende Dienstleistungen für selbst
 $lang['go_premium'] = 'Premium erwerben';
 $lang['notify_users_on_create_question'] = 'Möchten Sie den Kunden über diesen neuen Termin informieren?';
 $lang['notify_users_on_delete_question'] = 'Möchten Sie den Kunden über die Stornierung des Termins informieren?';
+
+$lang['sort_services_and_categories'] = 'Sortierung von Dienstleistungen und Kategorien aktivieren';
+$lang['sort_services_and_categories_hint'] = 'Admin-Sortiersteuerung anzeigen und benutzerdefinierte Reihenfolge bei der Buchung verwenden.';
+$lang['move_up'] = 'Nach oben';
+$lang['move_down'] = 'Nach unten';
+
 // End

--- a/application/language/greek/translations_lang.php
+++ b/application/language/greek/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Προσφέρουμε ολοκληρωμένες 
 $lang['go_premium'] = 'Αναβάθμιση σε Premium';
 $lang['notify_users_on_create_question'] = 'Θέλετε να ειδοποιήσετε τον πελάτη για αυτό το νέο ραντεβού;';
 $lang['notify_users_on_delete_question'] = 'Θέλετε να ειδοποιήσετε τον πελάτη για την ακύρωση του ραντεβού;';
+
+$lang['sort_services_and_categories'] = 'Ενεργοποίηση ταξινόμησης υπηρεσιών και κατηγοριών';
+$lang['sort_services_and_categories_hint'] = 'Εμφάνιση στοιχείων ελέγχου ταξινόμησης διαχειριστή και χρήση προσαρμοσμένης σειράς στην κράτηση.';
+$lang['move_up'] = 'Μετακίνηση πάνω';
+$lang['move_down'] = 'Μετακίνηση κάτω';
+
 // End

--- a/application/language/hebrew/translations_lang.php
+++ b/application/language/hebrew/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'אנו מציעים שירותים מקצה לקצ
 $lang['go_premium'] = 'עבור ל-Premium';
 $lang['notify_users_on_create_question'] = 'האם ברצונך להודיע ללקוח על תור חדש זה?';
 $lang['notify_users_on_delete_question'] = 'האם ברצונך להודיע ללקוח על ביטול התור?';
+
+$lang['sort_services_and_categories'] = 'הפעל מיון שירותים וקטגוריות';
+$lang['sort_services_and_categories_hint'] = 'הצג פקדי מיון מנהל והשתמש בסדר מותאם אישית בהזמנה.';
+$lang['move_up'] = 'העלה למעלה';
+$lang['move_down'] = 'הורד למטה';
+
 // End

--- a/application/language/hindi/translations_lang.php
+++ b/application/language/hindi/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'हम स्व-होस्टेड सॉफ�
 $lang['go_premium'] = 'Premium पाएँ';
 $lang['notify_users_on_create_question'] = 'क्या आप इस नई अपॉइंटमेंट के बारे में ग्राहक को सूचित करना चाहेंगे?';
 $lang['notify_users_on_delete_question'] = 'क्या आप अपॉइंटमेंट रद्द होने के बारे में ग्राहक को सूचित करना चाहेंगे?';
+
+$lang['sort_services_and_categories'] = 'सेवा और श्रेणी सॉर्टिंग सक्षम करें';
+$lang['sort_services_and_categories_hint'] = 'व्यवस्थापक सॉर्टिंग नियंत्रण दिखाएं और बुकिंग में कस्टम ऑर्डर का उपयोग करें।';
+$lang['move_up'] = 'ऊपर ले जाएं';
+$lang['move_down'] = 'नीचे ले जाएं';
+
 // End

--- a/application/language/hungarian/translations_lang.php
+++ b/application/language/hungarian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Átfogó szolgáltatásokat kínálunk saját üze
 $lang['go_premium'] = 'Premium verzió';
 $lang['notify_users_on_create_question'] = 'Szeretné értesíteni az ügyfelet erről az új időpontról?';
 $lang['notify_users_on_delete_question'] = 'Szeretné értesíteni az ügyfelet az időpont törléséről?';
+
+$lang['sort_services_and_categories'] = 'Szolgáltatások és kategóriák rendezésének engedélyezése';
+$lang['sort_services_and_categories_hint'] = 'Admin rendezési vezérlők megjelenítése és egyéni sorrend használata a foglalásnál.';
+$lang['move_up'] = 'Fel';
+$lang['move_down'] = 'Le';
+
 // End

--- a/application/language/italian/translations_lang.php
+++ b/application/language/italian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Offriamo servizi completi per software self-hosted
 $lang['go_premium'] = 'Passa a Premium';
 $lang['notify_users_on_create_question'] = 'Vuoi notificare il cliente di questo nuovo appuntamento?';
 $lang['notify_users_on_delete_question'] = 'Vuoi notificare il cliente della cancellazione dell\'appuntamento?';
+
+$lang['sort_services_and_categories'] = 'Abilita ordinamento servizi e categorie';
+$lang['sort_services_and_categories_hint'] = 'Mostra i controlli di ordinamento admin e utilizza l\'ordine personalizzato nella prenotazione.';
+$lang['move_up'] = 'Sposta su';
+$lang['move_down'] = 'Sposta giù';
+
 // End

--- a/application/language/japanese/translations_lang.php
+++ b/application/language/japanese/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'セルフホスティングソフトウェア向�
 $lang['go_premium'] = 'Premium にアップグレード';
 $lang['notify_users_on_create_question'] = 'この新しい予約についてお客様に通知しますか？';
 $lang['notify_users_on_delete_question'] = '予約のキャンセルについてお客様に通知しますか？';
+
+$lang['sort_services_and_categories'] = 'サービスとカテゴリの並べ替えを有効にする';
+$lang['sort_services_and_categories_hint'] = '管理画面の並べ替えコントロールを表示し、予約時にカスタム順序を使用します。';
+$lang['move_up'] = '上に移動';
+$lang['move_down'] = '下に移動';
+
 // End

--- a/application/language/latvian/translations_lang.php
+++ b/application/language/latvian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Mēs piedāvājam pilna cikla pakalpojumus pašmit
 $lang['go_premium'] = 'Go Premium';
 $lang['notify_users_on_create_question'] = 'Vai vēlaties informēt klientu par šo jauno tikšanos?';
 $lang['notify_users_on_delete_question'] = 'Vai vēlaties informēt klientu par tikšanās atcelšanu?';
+
+$lang['sort_services_and_categories'] = 'Aktivizēt pakalpojumu un kategoriju kārtošanu';
+$lang['sort_services_and_categories_hint'] = 'Parādīt admin kārtošanas vadīklas un izmantot pielāgoto secību rezervēšanā.';
+$lang['move_up'] = 'Pārvietot uz augšu';
+$lang['move_down'] = 'Pārvietot uz leju';
+
 // End

--- a/application/language/lithuanian/translations_lang.php
+++ b/application/language/lithuanian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Siūlome visapusiškus sprendimus savarankiškai t
 $lang['go_premium'] = 'Go Premium';
 $lang['notify_users_on_create_question'] = 'Ar norite pranešti klientui apie šį naują susitikimą?';
 $lang['notify_users_on_delete_question'] = 'Ar norite pranešti klientui apie susitikimo atšaukimą?';
+
+$lang['sort_services_and_categories'] = 'Įjungti paslaugų ir kategorijų rūšiavimą';
+$lang['sort_services_and_categories_hint'] = 'Rodyti admin rūšiavimo valdiklius ir naudoti pasirinktinę tvarką rezervuojant.';
+$lang['move_up'] = 'Perkelti aukštyn';
+$lang['move_down'] = 'Perkelti žemyn';
+
 // End

--- a/application/language/luxembourgish/translations_lang.php
+++ b/application/language/luxembourgish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Mir bidden End-to-End Servicer fir selbst-gehost S
 $lang['go_premium'] = 'Go Premium';
 $lang['notify_users_on_create_question'] = 'Wëllt Dir de Client iwwer dësen neien Rendez-vous informéieren?';
 $lang['notify_users_on_delete_question'] = 'Wëllt Dir de Client iwwer d\'Annulléierung vum Rendez-vous informéieren?';
+
+$lang['sort_services_and_categories'] = 'Service a Kategorien Zortéierung aktivéieren';
+$lang['sort_services_and_categories_hint'] = 'Admin Zortéierungssteierung uweisen an déi personaliséiert Reiefolleg bei der Buchung benotzen.';
+$lang['move_up'] = 'No uewen';
+$lang['move_down'] = 'No ënnen';
+
 // End

--- a/application/language/marathi/translations_lang.php
+++ b/application/language/marathi/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'आम्ही सेल्फ-होस्टे
 $lang['go_premium'] = 'Premium मिळवा';
 $lang['notify_users_on_create_question'] = 'या नवीन भेटीबद्दल ग्राहकाला सूचित करू इच्छिता?';
 $lang['notify_users_on_delete_question'] = 'भेट रद्द झाल्याबद्दल ग्राहकाला सूचित करू इच्छिता?';
+
+$lang['sort_services_and_categories'] = 'सेवा आणि श्रेणी क्रमवारी सक्षम करा';
+$lang['sort_services_and_categories_hint'] = 'व्यवस्थापक क्रमवारी नियंत्रणे दाखवा आणि बुकिंगमध्ये सानुकूल क्रम वापरा.';
+$lang['move_up'] = 'वर हलवा';
+$lang['move_down'] = 'खाली हलवा';
+
 // End

--- a/application/language/norwegian/translations_lang.php
+++ b/application/language/norwegian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Vi tilbyr helhetlige tjenester for selvhostet prog
 $lang['go_premium'] = 'Bli Premium';
 $lang['notify_users_on_create_question'] = 'Vil du varsle kunden om denne nye avtalen?';
 $lang['notify_users_on_delete_question'] = 'Vil du varsle kunden om avbestillingen av avtalen?';
+
+$lang['sort_services_and_categories'] = 'Aktiver sortering av tjenester og kategorier';
+$lang['sort_services_and_categories_hint'] = 'Vis admin-sorteringskontroller og bruk tilpasset rekkefølge ved bestilling.';
+$lang['move_up'] = 'Flytt opp';
+$lang['move_down'] = 'Flytt ned';
+
 // End

--- a/application/language/persian/translations_lang.php
+++ b/application/language/persian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'ما خدمات جامع برای نرم‌افز�
 $lang['go_premium'] = 'دریافت Premium';
 $lang['notify_users_on_create_question'] = 'آیا می‌خواهید مشتری را از این نوبت جدید مطلع کنید؟';
 $lang['notify_users_on_delete_question'] = 'آیا می‌خواهید مشتری را از لغو نوبت مطلع کنید؟';
+
+$lang['sort_services_and_categories'] = 'فعال‌سازی مرتب‌سازی خدمات و دسته‌بندی‌ها';
+$lang['sort_services_and_categories_hint'] = 'نمایش کنترل‌های مرتب‌سازی مدیر و استفاده از ترتیب سفارشی در رزرو.';
+$lang['move_up'] = 'انتقال به بالا';
+$lang['move_down'] = 'انتقال به پایین';
+
 // End

--- a/application/language/polish/translations_lang.php
+++ b/application/language/polish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Oferujemy kompleksowe usługi dla samodzielnie hos
 $lang['go_premium'] = 'Przejdź na Premium';
 $lang['notify_users_on_create_question'] = 'Czy chcesz powiadomić klienta o tym nowym spotkaniu?';
 $lang['notify_users_on_delete_question'] = 'Czy chcesz powiadomić klienta o anulowaniu spotkania?';
+
+$lang['sort_services_and_categories'] = 'Włącz sortowanie usług i kategorii';
+$lang['sort_services_and_categories_hint'] = 'Pokaż elementy sterowania sortowaniem i używaj niestandardowej kolejności przy rezerwacji.';
+$lang['move_up'] = 'Przesuń w górę';
+$lang['move_down'] = 'Przesuń w dół';
+
 // End

--- a/application/language/portuguese-br/translations_lang.php
+++ b/application/language/portuguese-br/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Oferecemos serviços completos para software auto-
 $lang['go_premium'] = 'Seja Premium';
 $lang['notify_users_on_create_question'] = 'Gostaria de notificar o cliente sobre este novo agendamento?';
 $lang['notify_users_on_delete_question'] = 'Gostaria de notificar o cliente sobre o cancelamento do agendamento?';
+
+$lang['sort_services_and_categories'] = 'Ativar ordenação de serviços e categorias';
+$lang['sort_services_and_categories_hint'] = 'Mostrar controles de ordenação admin e usar a ordem personalizada no agendamento.';
+$lang['move_up'] = 'Mover para cima';
+$lang['move_down'] = 'Mover para baixo';
+
 // End

--- a/application/language/portuguese/translations_lang.php
+++ b/application/language/portuguese/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Oferecemos serviços completos para software auto-
 $lang['go_premium'] = 'Obter Premium';
 $lang['notify_users_on_create_question'] = 'Gostaria de notificar o cliente sobre este novo agendamento?';
 $lang['notify_users_on_delete_question'] = 'Gostaria de notificar o cliente sobre o cancelamento do agendamento?';
+
+$lang['sort_services_and_categories'] = 'Ativar ordenação de serviços e categorias';
+$lang['sort_services_and_categories_hint'] = 'Mostrar controles de ordenação admin e usar a ordem personalizada na reserva.';
+$lang['move_up'] = 'Mover para cima';
+$lang['move_down'] = 'Mover para baixo';
+
 // End

--- a/application/language/romanian/translations_lang.php
+++ b/application/language/romanian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Oferim servicii complete pentru software auto-găz
 $lang['go_premium'] = 'Treceți la Premium';
 $lang['notify_users_on_create_question'] = 'Doriți să notificați clientul despre această nouă programare?';
 $lang['notify_users_on_delete_question'] = 'Doriți să notificați clientul despre anularea programării?';
+
+$lang['sort_services_and_categories'] = 'Activați sortarea serviciilor și categoriilor';
+$lang['sort_services_and_categories_hint'] = 'Afișați comenzile de sortare admin și folosiți ordinea personalizată în rezervare.';
+$lang['move_up'] = 'Mută sus';
+$lang['move_down'] = 'Mută jos';
+
 // End

--- a/application/language/russian/translations_lang.php
+++ b/application/language/russian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Мы предлагаем комплексные �
 $lang['go_premium'] = 'Перейти на Premium';
 $lang['notify_users_on_create_question'] = 'Хотите уведомить клиента о новой записи?';
 $lang['notify_users_on_delete_question'] = 'Хотите уведомить клиента об отмене записи?';
+
+$lang['sort_services_and_categories'] = 'Включить сортировку услуг и категорий';
+$lang['sort_services_and_categories_hint'] = 'Показывать элементы управления сортировкой и использовать пользовательский порядок при бронировании.';
+$lang['move_up'] = 'Вверх';
+$lang['move_down'] = 'Вниз';
+
 // End

--- a/application/language/serbian/translations_lang.php
+++ b/application/language/serbian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Nudimo kompletne usluge za softver koji sami hostu
 $lang['go_premium'] = 'Pređi na Premium';
 $lang['notify_users_on_create_question'] = 'Да ли желите да обавестите клијента о овом новом термину?';
 $lang['notify_users_on_delete_question'] = 'Да ли желите да обавестите клијента о отказивању термина?';
+
+$lang['sort_services_and_categories'] = 'Omogući sortiranje usluga i kategorija';
+$lang['sort_services_and_categories_hint'] = 'Prikaži kontrole sortiranja za admina i koristi prilagođeni redosled pri rezervaciji.';
+$lang['move_up'] = 'Pomeri gore';
+$lang['move_down'] = 'Pomeri dole';
+
 // End

--- a/application/language/slovak/translations_lang.php
+++ b/application/language/slovak/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Ponúkame komplexné služby pre self-hosted softv
 $lang['go_premium'] = 'Prejsť na Premium';
 $lang['notify_users_on_create_question'] = 'Chcete zákazníka informovať o tomto novom termíne?';
 $lang['notify_users_on_delete_question'] = 'Chcete zákazníka informovať o zrušení termínu?';
+
+$lang['sort_services_and_categories'] = 'Povoliť triedenie služieb a kategórií';
+$lang['sort_services_and_categories_hint'] = 'Zobraziť ovládacie prvky triedenia pre admina a použiť vlastné poradie pri rezervácii.';
+$lang['move_up'] = 'Posunúť hore';
+$lang['move_down'] = 'Posunúť dole';
+
 // End

--- a/application/language/slovenian/translations_lang.php
+++ b/application/language/slovenian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Ponujamo celovite storitve za samo-gostovano progr
 $lang['go_premium'] = 'Nadgradi na Premium';
 $lang['notify_users_on_create_question'] = 'Ali želite stranko obvestiti o tem novem terminu?';
 $lang['notify_users_on_delete_question'] = 'Ali želite stranko obvestiti o preklicu termina?';
+
+$lang['sort_services_and_categories'] = 'Omogoči razvrščanje storitev in kategorij';
+$lang['sort_services_and_categories_hint'] = 'Prikaži kontrole razvrščanja za admina in uporabi prilagojen vrstni red pri rezervaciji.';
+$lang['move_up'] = 'Premakni gor';
+$lang['move_down'] = 'Premakni dol';
+
 // End

--- a/application/language/spanish/translations_lang.php
+++ b/application/language/spanish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Ofrecemos servicios integrales para software autoa
 $lang['go_premium'] = 'Obtener Premium';
 $lang['notify_users_on_create_question'] = '¿Desea notificar al cliente sobre esta nueva cita?';
 $lang['notify_users_on_delete_question'] = '¿Desea notificar al cliente sobre la cancelación de la cita?';
+
+$lang['sort_services_and_categories'] = 'Activar ordenación de servicios y categorías';
+$lang['sort_services_and_categories_hint'] = 'Mostrar controles de ordenación admin y usar el orden personalizado en la reserva.';
+$lang['move_up'] = 'Subir';
+$lang['move_down'] = 'Bajar';
+
 // End

--- a/application/language/swedish/translations_lang.php
+++ b/application/language/swedish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Vi erbjuder heltäckande tjänster för egen-hosta
 $lang['go_premium'] = 'Bli Premium';
 $lang['notify_users_on_create_question'] = 'Vill du skicka en avisering om det nya mötet till kunden?';
 $lang['notify_users_on_delete_question'] = 'Vill du skicka en avisering om avbokningen till kunden?';
+
+$lang['sort_services_and_categories'] = 'Aktivera sortering av tjänster och kategorier';
+$lang['sort_services_and_categories_hint'] = 'Visa admin-sorteringskontroller och använd anpassad ordning vid bokning.';
+$lang['move_up'] = 'Flytta upp';
+$lang['move_down'] = 'Flytta ner';
+
 // End

--- a/application/language/thai/translations_lang.php
+++ b/application/language/thai/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'เรามีบริการครบวง�
 $lang['go_premium'] = 'อัปเกรด Premium';
 $lang['notify_users_on_create_question'] = 'คุณต้องการแจ้งลูกค้าเกี่ยวกับการนัดหมายใหม่นี้หรือไม่?';
 $lang['notify_users_on_delete_question'] = 'คุณต้องการแจ้งลูกค้าเกี่ยวกับการยกเลิกนัดหมายนี้หรือไม่?';
+
+$lang['sort_services_and_categories'] = 'เปิดใช้งานการจัดเรียงบริการและหมวดหมู่';
+$lang['sort_services_and_categories_hint'] = 'แสดงตัวควบคุมการจัดเรียงสำหรับผู้ดูแลและใช้ลำดับที่กำหนดเองในการจอง';
+$lang['move_up'] = 'เลื่อนขึ้น';
+$lang['move_down'] = 'เลื่อนลง';
+
 // End

--- a/application/language/traditional-chinese/translations_lang.php
+++ b/application/language/traditional-chinese/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = '我們為自架軟體提供端到端服務，包�
 $lang['go_premium'] = '升級 Premium';
 $lang['notify_users_on_create_question'] = '您想通知客戶這個新預約嗎？';
 $lang['notify_users_on_delete_question'] = '您想通知客戶預約取消嗎？';
+
+$lang['sort_services_and_categories'] = '啟用服務與分類排序';
+$lang['sort_services_and_categories_hint'] = '顯示管理排序控制項並在預訂中使用自訂順序。';
+$lang['move_up'] = '上移';
+$lang['move_down'] = '下移';
+
 // End

--- a/application/language/turkish/translations_lang.php
+++ b/application/language/turkish/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Kendi sunucunuzda barındırılan yazılımlar iç
 $lang['go_premium'] = 'Premium\'a Geç';
 $lang['notify_users_on_create_question'] = 'Bu yeni randevu hakkında müşteriyi bilgilendirmek ister misiniz?';
 $lang['notify_users_on_delete_question'] = 'Randevu iptali hakkında müşteriyi bilgilendirmek ister misiniz?';
+
+$lang['sort_services_and_categories'] = 'Hizmet ve Kategori Sıralamasını Etkinleştir';
+$lang['sort_services_and_categories_hint'] = 'Yönetici sıralama kontrollerini göster ve rezervasyonda özel sırayı kullan.';
+$lang['move_up'] = 'Yukarı Taşı';
+$lang['move_down'] = 'Aşağı Taşı';
+
 // End

--- a/application/language/ukrainian/translations_lang.php
+++ b/application/language/ukrainian/translations_lang.php
@@ -574,4 +574,10 @@ $lang['about_app_premium'] = 'Ми пропонуємо комплексні п�
 $lang['go_premium'] = 'Перейти на Premium';
 $lang['notify_users_on_create_question'] = 'Бажаєте повідомити клієнта про цей новий запис?';
 $lang['notify_users_on_delete_question'] = 'Бажаєте повідомити клієнта про скасування запису?';
+
+$lang['sort_services_and_categories'] = 'Увімкнути сортування послуг і категорій';
+$lang['sort_services_and_categories_hint'] = 'Показувати елементи керування сортуванням і використовувати користувацький порядок при бронюванні.';
+$lang['move_up'] = 'Вгору';
+$lang['move_down'] = 'Вниз';
+
 // End

--- a/application/migrations/070_add_service_sorting_setting.php
+++ b/application/migrations/070_add_service_sorting_setting.php
@@ -1,0 +1,88 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed');
+
+/* ----------------------------------------------------------------------------
+ * Easy!Appointments - Online Appointment Scheduler
+ *
+ * @package     EasyAppointments
+ * @author      A.Tselegidis <alextselegidis@gmail.com>
+ * @copyright   Copyright (c) Alex Tselegidis
+ * @license     https://opensource.org/licenses/GPL-3.0 - GPLv3
+ * @link        https://easyappointments.org
+ * @since       v1.5.0
+ * ---------------------------------------------------------------------------- */
+
+class Migration_Add_service_sorting_setting extends EA_Migration
+{
+    /**
+     * Upgrade method.
+     */
+    public function up(): void
+    {
+        if (!$this->db->field_exists('position', 'services')) {
+            $this->dbforge->add_column('services', [
+                'position' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'null' => false,
+                    'default' => 0,
+                    'after' => 'id_service_categories',
+                ],
+            ]);
+        }
+
+        if (!$this->db->field_exists('position', 'service_categories')) {
+            $this->dbforge->add_column('service_categories', [
+                'position' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'null' => false,
+                    'default' => 0,
+                    'after' => 'description',
+                ],
+            ]);
+        }
+
+        $this->seed_positions('services');
+        $this->seed_positions('service_categories');
+
+        if (!$this->db->get_where('settings', ['name' => 'sort_services_and_categories'])->row_array()) {
+            $this->db->insert('settings', [
+                'name' => 'sort_services_and_categories',
+                'value' => '0',
+            ]);
+        }
+    }
+
+    /**
+     * Downgrade method.
+     */
+    public function down(): void
+    {
+        $this->db->delete('settings', ['name' => 'sort_services_and_categories']);
+
+        if ($this->db->field_exists('position', 'services')) {
+            $this->dbforge->drop_column('services', 'position');
+        }
+
+        if ($this->db->field_exists('position', 'service_categories')) {
+            $this->dbforge->drop_column('service_categories', 'position');
+        }
+    }
+
+    /**
+     * Seed existing rows with deterministic positions.
+     */
+    private function seed_positions(string $table): void
+    {
+        $rows = $this->db
+            ->select('id')
+            ->from($table)
+            ->order_by('update_datetime DESC, id ASC')
+            ->get()
+            ->result_array();
+
+        foreach ($rows as $index => $row) {
+            $this->db->update($table, ['position' => $index + 1], ['id' => $row['id']]);
+        }
+    }
+}

--- a/application/models/Service_categories_model.php
+++ b/application/models/Service_categories_model.php
@@ -25,6 +25,7 @@ class Service_categories_model extends EA_Model
      */
     protected array $casts = [
         'id' => 'integer',
+        'position' => 'integer',
     ];
 
     /**
@@ -97,6 +98,10 @@ class Service_categories_model extends EA_Model
     {
         $service_category['create_datetime'] = date('Y-m-d H:i:s');
         $service_category['update_datetime'] = date('Y-m-d H:i:s');
+
+        if (!isset($service_category['position'])) {
+            $service_category['position'] = $this->get_next_position();
+        }
 
         if (!$this->db->insert('service_categories', $service_category)) {
             throw new RuntimeException('Could not insert service-category.');
@@ -244,6 +249,70 @@ class Service_categories_model extends EA_Model
         }
 
         return $service_categories;
+    }
+
+    /**
+     * Move a service category one position up or down.
+     *
+     * @param int $service_category_id Service category ID.
+     * @param string $direction Direction, either "up" or "down".
+     */
+    public function move_position(int $service_category_id, string $direction): void
+    {
+        $service_categories = $this->normalize_positions();
+
+        $index = array_search($service_category_id, array_column($service_categories, 'id'), true);
+
+        if ($index === false) {
+            throw new InvalidArgumentException(
+                'The provided service-category ID was not found in the database: ' . $service_category_id,
+            );
+        }
+
+        $target_index = $direction === 'up' ? $index - 1 : $index + 1;
+
+        if (!isset($service_categories[$target_index])) {
+            return;
+        }
+
+        $current = $service_categories[$index];
+        $target = $service_categories[$target_index];
+
+        $this->db->update('service_categories', ['position' => $target['position']], ['id' => $current['id']]);
+        $this->db->update('service_categories', ['position' => $current['position']], ['id' => $target['id']]);
+    }
+
+    /**
+     * Normalize positions and return all service categories in custom order.
+     *
+     * @return array
+     */
+    private function normalize_positions(): array
+    {
+        $service_categories = $this->db
+            ->select('id, position')
+            ->from('service_categories')
+            ->order_by($this->quote_order_by('position ASC, update_datetime DESC, id ASC'))
+            ->get()
+            ->result_array();
+
+        foreach ($service_categories as $index => &$service_category) {
+            $service_category['id'] = (int) $service_category['id'];
+            $service_category['position'] = $index + 1;
+            $this->db->update('service_categories', ['position' => $service_category['position']], [
+                'id' => $service_category['id'],
+            ]);
+        }
+
+        return $service_categories;
+    }
+
+    /**
+     * Get the next available position.
+     */
+    private function get_next_position(): int
+    {
+        return ((int) $this->db->select_max('position')->get('service_categories')->row()->position) + 1;
     }
 
     /**

--- a/application/models/Services_model.php
+++ b/application/models/Services_model.php
@@ -29,6 +29,7 @@ class Services_model extends EA_Model
         'attendants_number' => 'integer',
         'is_private' => 'boolean',
         'id_service_categories' => 'integer',
+        'position' => 'integer',
     ];
 
     /**
@@ -146,6 +147,10 @@ class Services_model extends EA_Model
         $provider_ids = $service['providers'] ?? [];
 
         unset($service['providers']);
+
+        if (!isset($service['position'])) {
+            $service['position'] = $this->get_next_position();
+        }
 
         if (!$this->db->insert('services', $service)) {
             throw new RuntimeException('Could not insert service.');
@@ -311,6 +316,10 @@ class Services_model extends EA_Model
      */
     public function get_available_services(bool $without_private = false): array
     {
+        $order_by = setting('sort_services_and_categories', '0')
+            ? 'service_categories.position ASC, services.position ASC, services.update_datetime DESC'
+            : 'services.name ASC';
+
         if ($without_private) {
             $this->db->where('services.is_private', false);
         }
@@ -318,12 +327,12 @@ class Services_model extends EA_Model
         $services = $this->db
             ->distinct()
             ->select(
-                'services.*, service_categories.name AS service_category_name, service_categories.id AS service_category_id',
+                'services.*, service_categories.name AS service_category_name, service_categories.id AS service_category_id, service_categories.position AS service_category_position',
             )
-            ->from('services')
-            ->join('services_providers', 'services_providers.id_services = services.id', 'inner')
-            ->join('service_categories', 'service_categories.id = services.id_service_categories', 'left')
-            ->order_by('name ASC')
+            ->from('services AS services')
+            ->join('services_providers AS services_providers', 'services_providers.id_services = services.id', 'inner')
+            ->join('service_categories AS service_categories', 'service_categories.id = services.id_service_categories', 'left')
+            ->order_by($order_by, '', false)
             ->get()
             ->result_array();
 
@@ -332,6 +341,66 @@ class Services_model extends EA_Model
         }
 
         return $services;
+    }
+
+    /**
+     * Move a service one position up or down.
+     *
+     * @param int $service_id Service ID.
+     * @param string $direction Direction, either "up" or "down".
+     */
+    public function move_position(int $service_id, string $direction): void
+    {
+        $services = $this->normalize_positions();
+
+        $index = array_search($service_id, array_column($services, 'id'), true);
+
+        if ($index === false) {
+            throw new InvalidArgumentException('The provided service ID was not found in the database: ' . $service_id);
+        }
+
+        $target_index = $direction === 'up' ? $index - 1 : $index + 1;
+
+        if (!isset($services[$target_index])) {
+            return;
+        }
+
+        $current = $services[$index];
+        $target = $services[$target_index];
+
+        $this->db->update('services', ['position' => $target['position']], ['id' => $current['id']]);
+        $this->db->update('services', ['position' => $current['position']], ['id' => $target['id']]);
+    }
+
+    /**
+     * Normalize positions and return all services in custom order.
+     *
+     * @return array
+     */
+    private function normalize_positions(): array
+    {
+        $services = $this->db
+            ->select('id, position')
+            ->from('services')
+            ->order_by($this->quote_order_by('position ASC, update_datetime DESC, id ASC'))
+            ->get()
+            ->result_array();
+
+        foreach ($services as $index => &$service) {
+            $service['id'] = (int) $service['id'];
+            $service['position'] = $index + 1;
+            $this->db->update('services', ['position' => $service['position']], ['id' => $service['id']]);
+        }
+
+        return $services;
+    }
+
+    /**
+     * Get the next available position.
+     */
+    private function get_next_position(): int
+    {
+        return ((int) $this->db->select_max('position')->get('services')->row()->position) + 1;
     }
 
     /**
@@ -390,11 +459,15 @@ class Services_model extends EA_Model
     public function search(string $keyword, ?int $limit = null, ?int $offset = null, ?string $order_by = null): array
     {
         $services = $this->db
-            ->select()
+            ->select(
+                'services.*, service_categories.name AS service_category_name, service_categories.id AS service_category_id',
+            )
             ->from('services')
+            ->join('service_categories', 'service_categories.id = services.id_service_categories', 'left')
             ->group_start()
-            ->like('name', $keyword)
-            ->or_like('description', $keyword)
+            ->like('services.name', $keyword)
+            ->or_like('services.description', $keyword)
+            ->or_like('service_categories.name', $keyword)
             ->group_end()
             ->limit($limit)
             ->offset($offset)

--- a/application/views/pages/general_settings.php
+++ b/application/views/pages/general_settings.php
@@ -192,6 +192,24 @@
                                     </div>
                                 </div>
 
+                                <div class="border rounded mb-3 p-3">
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox"
+                                               id="sort-services-and-categories"
+                                               data-field="sort_services_and_categories">
+
+                                        <label class="form-check-label" for="sort-services-and-categories">
+                                            <?= lang('sort_services_and_categories') ?>
+                                        </label>
+                                    </div>
+
+                                    <div class="form-text text-muted">
+                                        <small>
+                                            <?= lang('sort_services_and_categories_hint') ?>
+                                        </small>
+                                    </div>
+                                </div>
+
                                 <div class="mb-3">
                                     <label class="form-label" for="default-language">
                                         <?= lang('default_language') ?>

--- a/assets/js/http/service_categories_http_client.js
+++ b/assets/js/http/service_categories_http_client.js
@@ -122,6 +122,26 @@ App.Http.ServiceCategories = (function () {
         return $.post(url, data);
     }
 
+    /**
+     * Move a service-category one position up or down.
+     *
+     * @param {Number} serviceCategoryId
+     * @param {String} direction
+     *
+     * @return {Object}
+     */
+    function movePosition(serviceCategoryId, direction) {
+        const url = App.Utils.Url.siteUrl('service_categories/move_position');
+
+        const data = {
+            csrf_token: vars('csrf_token'),
+            service_category_id: serviceCategoryId,
+            direction,
+        };
+
+        return $.post(url, data);
+    }
+
     return {
         save,
         store,
@@ -129,5 +149,6 @@ App.Http.ServiceCategories = (function () {
         destroy,
         search,
         find,
+        movePosition,
     };
 })();

--- a/assets/js/http/services_http_client.js
+++ b/assets/js/http/services_http_client.js
@@ -122,6 +122,26 @@ App.Http.Services = (function () {
         return $.post(url, data);
     }
 
+    /**
+     * Move a service one position up or down.
+     *
+     * @param {Number} serviceId
+     * @param {String} direction
+     *
+     * @return {Object}
+     */
+    function movePosition(serviceId, direction) {
+        const url = App.Utils.Url.siteUrl('services/move_position');
+
+        const data = {
+            csrf_token: vars('csrf_token'),
+            service_id: serviceId,
+            direction,
+        };
+
+        return $.post(url, data);
+    }
+
     return {
         save,
         store,
@@ -129,5 +149,6 @@ App.Http.Services = (function () {
         destroy,
         search,
         find,
+        movePosition,
     };
 })();

--- a/assets/js/pages/service_categories.js
+++ b/assets/js/pages/service_categories.js
@@ -20,6 +20,7 @@ App.Pages.ServiceCategories = (function () {
     const $id = $('#id');
     const $name = $('#name');
     const $description = $('#description');
+    const customSortingEnabled = Boolean(vars('custom_sorting_enabled'));
     let filterResults = {};
     let filterLimit = 20;
 
@@ -73,6 +74,31 @@ App.Pages.ServiceCategories = (function () {
             $serviceCategories.find('.record-details .form-label span').prop('hidden', false);
             $filterServiceCategories.find('button').prop('disabled', true);
             $filterServiceCategories.find('.results').css('color', '#AAA');
+        });
+
+        /**
+         * Event: Move Service-Category Button "Click"
+         */
+        $serviceCategories.on('click', '.move-service-category', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if ($filterServiceCategories.find('.filter').prop('disabled')) {
+                return;
+            }
+
+            const $button = $(event.currentTarget);
+
+            App.Http.ServiceCategories.movePosition(
+                $button.closest('.service-category-row').data('id'),
+                $button.data('direction'),
+            ).then(() => {
+                App.Pages.ServiceCategories.filter(
+                    $filterServiceCategories.find('.key').val(),
+                    $id.val() || null,
+                    Boolean($id.val()),
+                );
+            });
         });
 
         /**
@@ -301,10 +327,37 @@ App.Pages.ServiceCategories = (function () {
      * @return {String} Returns the record HTML code.
      */
     function getFilterHtml(serviceCategory) {
+        const controls = customSortingEnabled && !$filterServiceCategories.find('.key').val()
+            ? $('<span/>', {
+                  'class': 'btn-group btn-group-sm float-end',
+                  'html': [
+                      $('<button/>', {
+                          'type': 'button',
+                          'class': 'btn btn-outline-secondary move-service-category',
+                          'data-direction': 'up',
+                          'title': lang('move_up'),
+                          'html': $('<i/>', {
+                              'class': 'fas fa-arrow-up',
+                          }),
+                      }),
+                      $('<button/>', {
+                          'type': 'button',
+                          'class': 'btn btn-outline-secondary move-service-category',
+                          'data-direction': 'down',
+                          'title': lang('move_down'),
+                          'html': $('<i/>', {
+                              'class': 'fas fa-arrow-down',
+                          }),
+                      }),
+                  ],
+              })
+            : null;
+
         return $('<div/>', {
             'class': 'service-category-row entry',
             'data-id': serviceCategory.id,
             'html': [
+                controls,
                 $('<strong/>', {
                     'text': serviceCategory.name,
                 }),

--- a/assets/js/pages/services.js
+++ b/assets/js/pages/services.js
@@ -29,6 +29,7 @@ App.Pages.Services = (function () {
     const $description = $('#description');
     const $filterServices = $('#filter-services');
     const $color = $('#color');
+    const customSortingEnabled = Boolean(vars('custom_sorting_enabled'));
     let filterResults = {};
     let filterLimit = 20;
 
@@ -100,6 +101,26 @@ App.Pages.Services = (function () {
             App.Components.ColorSelection.enable($color);
             $('#service-providers input:checkbox').prop('disabled', false);
             $('#select-all-providers, #select-none-providers').prop('disabled', false);
+        });
+
+        /**
+         * Event: Move Service Button "Click"
+         */
+        $services.on('click', '.move-service', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if ($filterServices.find('.filter').prop('disabled')) {
+                return;
+            }
+
+            const $button = $(event.currentTarget);
+
+            App.Http.Services.movePosition($button.closest('.service-row').data('id'), $button.data('direction')).then(
+                () => {
+                    App.Pages.Services.filter($filterServices.find('.key').val(), $id.val() || null, Boolean($id.val()));
+                },
+            );
         });
 
         /**
@@ -405,9 +426,7 @@ App.Pages.Services = (function () {
 
             $filterServices.find('.results').empty();
 
-            response.forEach((service) => {
-                $filterServices.find('.results').append(App.Pages.Services.getFilterHtml(service)).append($('<hr/>'));
-            });
+            renderGroupedFilterResults(response);
 
             if (response.length === 0) {
                 $filterServices.find('.results').append(
@@ -434,6 +453,56 @@ App.Pages.Services = (function () {
     }
 
     /**
+     * Render services grouped by category.
+     *
+     * @param {Array} services
+     */
+    function renderGroupedFilterResults(services) {
+        const groupedServices = {};
+        const uncategorizedServices = [];
+
+        services.forEach((service) => {
+            if (!service.service_category_id) {
+                uncategorizedServices.push(service);
+                return;
+            }
+
+            const categoryName = service.service_category_name || lang('category');
+
+            if (!groupedServices[categoryName]) {
+                groupedServices[categoryName] = [];
+            }
+
+            groupedServices[categoryName].push(service);
+        });
+
+        Object.keys(groupedServices).forEach((categoryName) => {
+            appendCategoryGroup(categoryName, groupedServices[categoryName]);
+        });
+
+        if (uncategorizedServices.length) {
+            appendCategoryGroup(lang('no_category'), uncategorizedServices);
+        }
+    }
+
+    /**
+     * Append a category group to the results list.
+     *
+     * @param {String} categoryName
+     * @param {Array} services
+     */
+    function appendCategoryGroup(categoryName, services) {
+        $('<div/>', {
+            'class': 'text-muted text-uppercase small fw-bold mb-2 mt-3',
+            'text': categoryName,
+        }).appendTo($filterServices.find('.results'));
+
+        services.forEach((service) => {
+            $filterServices.find('.results').append(App.Pages.Services.getFilterHtml(service)).append($('<hr/>'));
+        });
+    }
+
+    /**
      * Get Filter HTML
      *
      * Get a service row HTML code that is going to be displayed on the filter results list.
@@ -447,10 +516,37 @@ App.Pages.Services = (function () {
 
         const info = service.duration + ' min - ' + service.price + ' ' + service.currency;
 
+        const controls = customSortingEnabled && !$filterServices.find('.key').val()
+            ? $('<span/>', {
+                  'class': 'btn-group btn-group-sm float-end',
+                  'html': [
+                      $('<button/>', {
+                          'type': 'button',
+                          'class': 'btn btn-outline-secondary move-service',
+                          'data-direction': 'up',
+                          'title': lang('move_up'),
+                          'html': $('<i/>', {
+                              'class': 'fas fa-arrow-up',
+                          }),
+                      }),
+                      $('<button/>', {
+                          'type': 'button',
+                          'class': 'btn btn-outline-secondary move-service',
+                          'data-direction': 'down',
+                          'title': lang('move_down'),
+                          'html': $('<i/>', {
+                              'class': 'fas fa-arrow-down',
+                          }),
+                      }),
+                  ],
+              })
+            : null;
+
         return $('<div/>', {
             'class': 'service-row entry',
             'data-id': service.id,
             'html': [
+                controls,
                 $('<strong/>', {
                     'text': name,
                 }),
@@ -524,5 +620,6 @@ App.Pages.Services = (function () {
         display,
         select,
         addEventListeners,
+        renderGroupedFilterResults,
     };
 })();


### PR DESCRIPTION
Adds optional manual sorting for service categories and services, controlled from General Settings.

When enabled, admins can move categories/services up or down in the admin UI, and that custom order is reflected in the frontend booking flow. When disabled, the app keeps the existing ordering behavior and hides the sorting controls.

## Why This Is Needed

Some businesses need their booking flow to present services in a deliberate order, not just by the previous default sorting logic. For example, high-priority services, common booking options, or seasonal offerings should be easy to place first without renaming records or relying on update timestamps.

This also improves admin usability by grouping services by category on the Services page, making larger service lists easier to scan and manage.

## What Changed

- Added a General Settings toggle for service/category sorting.
- Added `position` columns for services and service categories.
- Added admin up/down controls for sorting when the setting is enabled.
- Preserved old sorting behavior when the setting is disabled.
- Reflected custom ordering in the frontend booking service selector.
- Grouped admin services by category.
- Kept JS minimal and dependency-free.

## Example Scenarios

- A clinic wants “Consultation” and “Follow-up” services to appear before less common services.
- A salon wants categories ordered as “Hair”, “Nails”, then “Makeup” instead of default sorting.
- A seasonal business wants “Christmas Package” temporarily shown first.
- A business with many services wants the admin Services page grouped by category for easier management.

## Migration Warning

This branch adds a new migration.

My previous PRs also add migrations, so if multiple PRs are merged, please check and renumber the migration files as needed to avoid duplicate migration numbers.

## Note

I noticed there was a previous PR attempting similar functionality, but it looked outdated and not clean enough to merge directly. This implementation is based on the current codebase and keeps the feature optional, backwards-compatible, and minimal in the admin UI.

<img width="830" height="921" alt="CleanShot 2026-06-06 at 00 08 10" src="https://github.com/user-attachments/assets/b133f900-d80b-4aab-b80d-27b19bbb0617" />
