### PR TITLE
Improve mobile booking flow with fixed actions, clearer validation, and cleaner widgets

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -17,6 +17,196 @@
     }
 }
 
+@media (max-width: 767.98px) {
+    html,
+    body {
+        min-height: 100%;
+        overflow-x: hidden;
+    }
+
+    #main.container {
+        max-width: none;
+        padding: 0;
+    }
+
+    #main .wrapper {
+        min-height: 100vh !important;
+        align-items: stretch !important;
+    }
+
+    #book-appointment-wizard {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        padding-top: 104px !important;
+        padding-bottom: 86px !important;
+    }
+
+    #book-appointment-wizard #header {
+        position: fixed;
+        top: 0;
+        right: 0;
+        left: 0;
+        z-index: 1030;
+        min-height: 96px;
+        padding: 10px 14px !important;
+        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+    }
+
+    #book-appointment-wizard #company-name {
+        display: grid !important;
+        grid-template-columns: 42px minmax(0, 1fr);
+        column-gap: 10px;
+        align-items: center;
+        width: 100%;
+        margin: 0 !important;
+        text-align: left !important;
+        font-size: 1rem !important;
+        line-height: 1.2 !important;
+    }
+
+    #book-appointment-wizard #company-logo {
+        width: 42px;
+        max-width: 42px;
+        max-height: 42px !important;
+        margin: 0 !important;
+        object-fit: contain;
+    }
+
+    #book-appointment-wizard #company-name > span:not(.display-booking-selection) {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    #book-appointment-wizard #company-name > .d-flex {
+        grid-column: 2;
+        justify-content: flex-start !important;
+        min-width: 0;
+    }
+
+    #book-appointment-wizard .display-booking-selection {
+        display: block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 0.75rem;
+    }
+
+    #book-appointment-wizard #steps {
+        width: 168px !important;
+        margin: 10px auto 0 !important;
+    }
+
+    #book-appointment-wizard .wizard-frame {
+        flex: 1 1 auto;
+        padding: 20px 25px 0 !important;
+    }
+
+    #book-appointment-wizard .frame-container {
+        min-height: 0 !important;
+        padding: 10px 0 0 !important;
+    }
+
+    #book-appointment-wizard .frame-title {
+        margin: 0 0 16px !important;
+        font-size: 1.35rem;
+    }
+
+    #book-appointment-wizard #select-date {
+        margin-top: 8px !important;
+        margin-bottom: 8px !important;
+    }
+
+    #book-appointment-wizard #select-time {
+        max-width: none !important;
+        padding-top: 8px !important;
+    }
+
+    #book-appointment-wizard #available-hours {
+        max-height: none !important;
+        overflow: visible !important;
+        padding-right: 0 !important;
+    }
+
+    #book-appointment-wizard #available-hours .available-hour {
+        width: 100%;
+    }
+
+    #book-appointment-wizard .command-buttons {
+        position: fixed;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 1030;
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        justify-content: space-between;
+        margin: 0 !important;
+        padding: 12px 14px calc(12px + env(safe-area-inset-bottom));
+        background: var(--bs-body-bg);
+        border-top: 1px solid var(--bs-border-color);
+        box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.08);
+    }
+
+    #book-appointment-wizard .command-buttons > span {
+        display: none;
+    }
+
+    #book-appointment-wizard .command-buttons .btn,
+    #book-appointment-wizard .command-buttons form {
+        flex: 1 1 0;
+        min-width: 0 !important;
+        margin: 0 !important;
+    }
+
+    #book-appointment-wizard .command-buttons .btn {
+        width: 100%;
+        padding: 10px 12px;
+        white-space: nowrap;
+    }
+
+    #book-appointment-wizard #frame-footer {
+        padding: 10px 14px !important;
+        font-size: 0.75rem;
+    }
+
+    #book-appointment-wizard .altcha-widget {
+        max-width: 100%;
+    }
+
+    #book-appointment-wizard .altcha-challenge {
+        padding: 10px !important;
+        border-radius: var(--bs-border-radius-sm);
+    }
+
+    #book-appointment-wizard .altcha-challenge > .d-flex {
+        gap: 8px;
+        align-items: center !important;
+    }
+
+    #book-appointment-wizard .altcha-verify-btn {
+        flex: 0 0 auto;
+        margin-right: 0 !important;
+        padding: 7px 10px;
+        font-size: 0.875rem;
+        line-height: 1.2;
+    }
+
+    #book-appointment-wizard .altcha-status {
+        min-width: 0;
+        font-size: 0.75rem;
+        line-height: 1.25;
+    }
+
+    #book-appointment-wizard .altcha-progress {
+        margin-top: 8px !important;
+    }
+}
+
 /* Active step indicator - dynamic state that changes via JavaScript */
 #book-appointment-wizard .book-step.active-step {
     height: 45px !important;
@@ -58,6 +248,31 @@
     color: var(--bs-white) !important;
 }
 
+#book-appointment-wizard .booking-step-alert {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    border: 1px solid rgba(var(--bs-warning-rgb), 0.35);
+    border-left: 4px solid var(--bs-warning);
+    border-radius: var(--bs-border-radius);
+    margin-bottom: 16px;
+    padding: 12px 14px;
+}
+
+#book-appointment-wizard .booking-step-alert::before {
+    content: '!';
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--bs-warning);
+    color: var(--bs-dark);
+    font-weight: 700;
+}
+
 /* Captcha refresh icon hover effect */
 #book-appointment-wizard .captcha-title .fa-sync-alt {
     cursor: pointer;
@@ -79,4 +294,36 @@
 
 #book-appointment-wizard .flatpickr-calendar.inline {
     margin: auto; 
+}
+
+#book-appointment-wizard .flatpickr-calendar.arrowTop::before,
+#book-appointment-wizard .flatpickr-calendar.arrowTop::after,
+#book-appointment-wizard .flatpickr-calendar.arrowBottom::before,
+#book-appointment-wizard .flatpickr-calendar.arrowBottom::after {
+    display: none;
+}
+
+@media (max-width: 767.98px) {
+    #book-appointment-wizard .book-step.active-step {
+        height: 34px !important;
+        width: 34px !important;
+        padding: 5px !important;
+        margin-right: 10px !important;
+    }
+
+    #book-appointment-wizard .book-step.active-step strong {
+        font-size: 16px !important;
+    }
+
+    #book-appointment-wizard .book-step:not(.active-step) {
+        height: 28px !important;
+        width: 28px !important;
+        padding: 5px !important;
+        margin-top: 3px !important;
+        margin-right: 8px !important;
+    }
+
+    #book-appointment-wizard .book-step:not(.active-step) strong {
+        font-size: 11px !important;
+    }
 }

--- a/assets/js/pages/booking.js
+++ b/assets/js/pages/booking.js
@@ -319,6 +319,47 @@ App.Pages.Booking = (function () {
         });
     }
 
+    function scrollToBookingError($target) {
+        if (!$target?.length) {
+            return;
+        }
+
+        const headerHeight = $('#header').outerHeight() || 0;
+        const $fieldTarget = $target.closest('.mb-3, .form-check, .field-col').length
+            ? $target.closest('.mb-3, .form-check, .field-col').first()
+            : $target;
+        const offset = headerHeight + 40;
+        const top = Math.max($fieldTarget.offset().top - offset, 0);
+
+        window.scrollTo({
+            top,
+            behavior: 'smooth',
+        });
+
+        if ($target.is('input, select, textarea, button')) {
+            setTimeout(() => $target[0].focus({preventScroll: true}), 350);
+        }
+    }
+
+    function showBookingAlert(message, $frame = $('.wizard-frame:visible'), $target = null) {
+        $('.booking-step-alert').remove();
+
+        const $alert = $('<div/>', {
+            'class': 'booking-step-alert alert alert-warning shadow-sm',
+            'role': 'alert',
+            'html': $('<span/>', {
+                'text': message,
+            }),
+        });
+
+        $frame.find('.frame-container').first().prepend($alert);
+        scrollToBookingError($target?.length ? $target : $alert);
+    }
+
+    function clearBookingAlert() {
+        $('.booking-step-alert').remove();
+    }
+
     /**
      * Add the page event listeners.
      */
@@ -415,9 +456,12 @@ App.Pages.Booking = (function () {
          */
         $('.button-next').on('click', (event) => {
             const $target = $(event.currentTarget);
+            const $frame = $target.closest('.wizard-frame');
 
             // If we are on the first step and there is no provider selected do not continue with the next step.
             if ($target.attr('data-step_index') === '1' && !$selectProvider.val()) {
+                const $missingSelection = !$selectService.val() ? $selectService : $selectProvider;
+                showBookingAlert(`${lang('select_service')} / ${lang('select_provider')}`, $frame, $missingSelection);
                 return;
             }
 
@@ -437,13 +481,7 @@ App.Pages.Booking = (function () {
             // If we are on the 2nd tab then the user should have an appointment hour selected.
             if ($target.attr('data-step_index') === '2') {
                 if (!$('.selected-hour').length) {
-                    if (!$('#select-hour-prompt').length) {
-                        $('<div/>', {
-                            'id': 'select-hour-prompt',
-                            'class': 'text-danger mb-4',
-                            'text': lang('appointment_hour_missing'),
-                        }).prependTo('#available-hours');
-                    }
+                    showBookingAlert(lang('appointment_hour_missing'), $frame, $availableHours);
                     return;
                 }
             }
@@ -452,6 +490,11 @@ App.Pages.Booking = (function () {
             // step.
             if ($target.attr('data-step_index') === '3') {
                 if (!App.Pages.Booking.validateCustomerForm()) {
+                    showBookingAlert(
+                        $('#form-message').text() || lang('fields_are_required'),
+                        $frame,
+                        $frame.find('.is-invalid:visible').first(),
+                    );
                     return; // Validation failed, do not continue.
                 } else {
                     App.Pages.Booking.updateConfirmFrame();
@@ -462,6 +505,8 @@ App.Pages.Booking = (function () {
                     }
                 }
             }
+
+            clearBookingAlert();
 
             // Display the next step tab (uses jquery animation effect).
             const nextTabIndex = parseInt($target.attr('data-step_index')) + 1;
@@ -491,6 +536,8 @@ App.Pages.Booking = (function () {
          * book wizard.
          */
         $('.button-back').on('click', (event) => {
+            clearBookingAlert();
+
             const prevTabIndex = parseInt($(event.currentTarget).attr('data-step_index')) - 1;
 
             // Update step indicator immediately
@@ -511,6 +558,7 @@ App.Pages.Booking = (function () {
          * Triggered whenever the user clicks on an available hour for his appointment.
          */
         $availableHours.on('click', '.available-hour', (event) => {
+            clearBookingAlert();
             $availableHours.find('.selected-hour').removeClass('selected-hour');
             $(event.target).addClass('selected-hour');
             App.Pages.Booking.updateConfirmFrame();
@@ -608,6 +656,7 @@ App.Pages.Booking = (function () {
 
             if ($acceptToTermsAndConditions.length && !$acceptToTermsAndConditions.prop('checked')) {
                 $acceptToTermsAndConditions.addClass('is-invalid');
+                showBookingAlert(lang('fields_are_required'), $('.wizard-frame:visible'), $acceptToTermsAndConditions);
                 return;
             }
 
@@ -617,8 +666,11 @@ App.Pages.Booking = (function () {
 
             if ($acceptToPrivacyPolicy.length && !$acceptToPrivacyPolicy.prop('checked')) {
                 $acceptToPrivacyPolicy.addClass('is-invalid');
+                showBookingAlert(lang('fields_are_required'), $('.wizard-frame:visible'), $acceptToPrivacyPolicy);
                 return;
             }
+
+            clearBookingAlert();
 
             App.Http.Booking.registerAppointment();
         });


### PR DESCRIPTION
This PR improves the booking wizard experience on mobile devices. The booking flow is currently hard to use on small screens because the header takes too much space, action buttons move out of view, validation failures can feel silent, and some widgets take more room than they need.

The update makes the mobile booking UI feel more app-like: a compact fixed header keeps progress visible, the main actions stay fixed at the bottom, validation messages clearly explain what is missing, and the page scrolls directly to the field that needs attention.

**What Changed**
- Added a compact fixed mobile header for the booking wizard.
- Added a fixed bottom action bar for Back / Next / Confirm buttons.
- Reduced excess mobile spacing in wizard steps.
- Made available time buttons full-width on mobile.
- Added styled validation alerts when required booking steps are incomplete.
- Scrolls to the actual missing/invalid field, accounting for the fixed header.
- Tightened the ALTCHA widget on mobile.
- Removed Flatpickr arrow pseudo-elements from the booking calendar.

**Why This Is Needed**
Mobile users often book appointments quickly, usually with one hand and limited screen space. Keeping the main action buttons visible removes unnecessary scrolling, while clear error messages reduce confusion when a required step is missed.

This also prevents cases where validation fails but the user does not know why, especially on longer forms where the invalid field may be off-screen.

**Example Scenarios**
- A customer taps Next without selecting a provider: they now see a styled warning and are taken to the provider selector.
- A customer forgets to pick an appointment time: the page scrolls to the time area and explains what is missing.
- A required contact field is empty: the first invalid field is brought into view with its label visible below the fixed header.
- A customer reaches confirmation but forgets terms/privacy: the checkbox is highlighted and scrolled into view.
- On mobile, the ALTCHA challenge no longer dominates the confirmation step.

<img width="374" height="668" alt="CleanShot 2026-06-06 at 02 29 47" src="https://github.com/user-attachments/assets/5555d58a-7082-42f6-9d35-3b8de4e872d1" />
