### PR TITLE
refactor(config): make database and email settings update-safe

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -4,7 +4,8 @@
 | -------------------------------------------------------------------
 | DATABASE CONNECTIVITY SETTINGS
 | -------------------------------------------------------------------
-| This file will contain the settings needed to access your database.
+| This file contains the database settings.
+| The settings are now saved in the config file for easy future updates.
 |
 | For complete instructions please consult the 'Database Connection'
 | page of the User Guide.
@@ -18,7 +19,7 @@
 |	['password'] The password used to connect to the database
 |	['database'] The name of the database you want to connect to
 |	['dbdriver'] The database type. ie: mysql.  Currently supported:
-				 mysql, mysqli, postgre, odbc, mssql, sqlite, oci8
+|				 mysql, mysqli, postgre, odbc, mssql, sqlite, oci8
 |	['dbprefix'] You can add an optional prefix, which will be added
 |				 to the table name when using the  Active Record class
 |	['pconnect'] TRUE/FALSE - Whether to use a persistent connection
@@ -46,24 +47,55 @@
 | the active record class
 */
 
-$active_group = 'default';
+$active_group = defined('Config::DB_ACTIVE_GROUP') && !empty(Config::DB_ACTIVE_GROUP) ? Config::DB_ACTIVE_GROUP : 'default';
 $query_builder = TRUE;
 
-$db['default']['hostname'] = Config::DB_HOST;
-$db['default']['username'] = Config::DB_USERNAME;
-$db['default']['password'] = Config::DB_PASSWORD;
-$db['default']['database'] = Config::DB_NAME;
-$db['default']['dbdriver'] = 'mysqli';
-$db['default']['dbprefix'] = 'ea_';
-$db['default']['pconnect'] = FALSE;
-$db['default']['db_debug'] = TRUE;
-$db['default']['cache_on'] = FALSE;
-$db['default']['cachedir'] = '';
-$db['default']['char_set'] = 'utf8mb4';
-$db['default']['dbcollat'] = 'utf8mb4_unicode_ci';
-$db['default']['swap_pre'] = '';
-$db['default']['autoinit'] = TRUE;
-$db['default']['stricton'] = FALSE;
+/* ====================================================================
+ * ATTENTION
+ * ====================================================================
+ * The configuration settings below are default values.
+ * To customize them, please set your own values in the main config file
+ * (config.php) to ensure they persist across application updates.
+ * Have a look into "config-sample.php" for an example of how to set your
+ * own database settings.
+ * ====================================================================
+ */
+
+$base_db_settings = [
+    'hostname' => 'mysql',
+    'username' => 'user',
+    'password' => 'password',
+    'database' => 'easyappointments',
+    'dbdriver' => 'mysqli',
+    'dbprefix' => 'ea_',
+    'pconnect' => FALSE,
+    'db_debug' => TRUE,
+    'cache_on' => FALSE,
+    'cachedir' => '',
+    'char_set' => 'utf8mb4',
+    'dbcollat' => 'utf8mb4_unicode_ci',
+    'swap_pre' => '',
+    'autoinit' => TRUE,
+    'stricton' => FALSE,
+];
+
+// The default database settings use the old database settings for backward compatibility.
+$db['default']['hostname'] = defined('Config::DB_HOST') && !empty(Config::DB_HOST) ? Config::DB_HOST : $base_db_settings['hostname'];
+$db['default']['username'] = defined('Config::DB_USERNAME') && !empty(Config::DB_USERNAME) ? Config::DB_USERNAME : $base_db_settings['username'];
+$db['default']['password'] = defined('Config::DB_PASSWORD') && !empty(Config::DB_PASSWORD) ? Config::DB_PASSWORD : $base_db_settings['password'];
+$db['default']['database'] = defined('Config::DB_NAME') && !empty(Config::DB_NAME) ? Config::DB_NAME : $base_db_settings['database'];
+
+// The default database settings use the new database settings for backward compatibility
+$db['default'] = array_replace($base_db_settings, $db['default']);
+
+if (defined(Config::class . '::DB_SETTINGS') && is_array(Config::DB_SETTINGS)) {
+    foreach (Config::DB_SETTINGS as $group => $settings) {
+        $db[$group] = array_replace(
+            $base_db_settings,
+            $settings
+        );
+    }
+}
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */

--- a/application/config/email.php
+++ b/application/config/email.php
@@ -1,8 +1,26 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed');
 
-// Add custom values by settings them to the $config array.
-// Example: $config['smtp_host'] = 'smtp.gmail.com';
-// @link https://codeigniter.com/user_guide/libraries/email.html
+/**
+ * Email Configuration
+ *
+ * This file provides default email settings for Easy!Appointments.
+ * Custom email settings should be configured in the main config file to ensure
+ * they persist across application updates. This file will be overwritten during updates.
+ * Example: 'smtp_host' => 'smtp.gmail.com';
+ *
+ * @link https://codeigniter.com/user_guide/libraries/email.html
+ */
+
+/* ====================================================================
+ * ATTENTION
+ * ====================================================================
+ * The configuration settings below are default values.
+ * To customize them, please set your own values in the main config file
+ * (config.php) to ensure they persist across application updates.
+ * Have a look into "config-sample.php" for an example of how to set your
+ * own email settings.
+ * ====================================================================
+ */
 
 $config['useragent'] = 'Easy!Appointments';
 $config['protocol'] = 'mail'; // or 'smtp'
@@ -19,3 +37,11 @@ $config['mailtype'] = 'html'; // or 'text'
 // $config['reply_to'] = '';
 $config['crlf'] = "\r\n";
 $config['newline'] = "\r\n";
+
+// default settings for email library, can be overridden in the main config file (config.php)
+if (defined(Config::class . '::EMAIL_SETTINGS') && is_array(Config::EMAIL_SETTINGS)) {
+    $config = array_replace($config, Config::EMAIL_SETTINGS ?? []);
+}
+
+/* End of file email.php */
+/* Location: ./application/config/email.php */

--- a/config-sample.php
+++ b/config-sample.php
@@ -37,11 +37,73 @@ class Config
     // ------------------------------------------------------------------------
     // DATABASE SETTINGS
     // ------------------------------------------------------------------------
-
-    const DB_HOST = 'mysql';
-    const DB_NAME = 'easyappointments';
-    const DB_USERNAME = 'user';
-    const DB_PASSWORD = 'password';
+    const DB_ACTIVE_GROUP = 'default';  // name of the group, can be anything you want. Defined in DB_SETTINGS below. e.x. "default", "custom1", "example2" etc.
+    const DB_SETTINGS = [
+        'default' => [  // name of the group, can be anything you want
+            /* REQUIRED - Change the following settings to match your database credentials */
+            'hostname' => 'mysql',                  // value of DB_HOST
+            'database' => 'easyappointments',       // value of DB_NAME
+            'username' => 'user',                   // value of DB_USERNAME
+            'password' => 'password',               // value of DB_PASSWORD
+            /* OPTIONAL - Use the following settings if you need different values instead of the defaults only! */
+            // 'dbdriver' => 'mysqli',
+            // 'dbprefix' => 'ea_',
+            // 'pconnect' => FALSE,
+            // 'db_debug' => TRUE,
+            // 'cache_on' => FALSE,
+            // 'cachedir' => '',
+            // 'char_set' => 'utf8mb4',
+            // 'dbcollat' => 'utf8mb4_unicode_ci',
+            // 'swap_pre' => '',
+            // 'autoinit' => TRUE,
+            // 'stricton' => FALSE,
+        ],
+        // 'custom1' => [
+        //     /* REQUIRED - Change the following settings to match your database credentials */
+        //     'hostname' => 'mysql',
+        //     'database' => 'easyappointments',
+        //     'username' => 'user',
+        //     'password' => 'password',
+        //     /* OPTIONAL params see above */
+        // ],
+        // 'example2' => [
+        //     /* REQUIRED - Change the following settings to match your database credentials */
+        //     'hostname' => 'mysql',
+        //     'database' => 'easyappointments',
+        //     'username' => 'user',
+        //     'password' => 'password',
+        //     /* OPTIONAL params see above */
+        // ],
+    ];
+    
+    // ------------------------------------------------------------------------
+    // EMAIL SETTINGS
+    // ------------------------------------------------------------------------
+    const EMAIL_SETTINGS = [
+        /* OPTIONAL - Use the following settings if you need different values instead of the defaults only! */
+        // 'useragent' => 'Easy!Appointments',
+        // 'protocol' => 'mail',   // or 'smtp'
+        // 'smtp_host' => '',
+        // 'smtp_user' => '',
+        // 'smtp_pass' => '',
+        // 'smtp_crypto' => 'ssl',  // or 'tls'
+        // 'smtp_port' => 25,
+        // 'starttls' => FALSE,
+        // 'smtp_debug' => 0,       // or '1'
+        // 'smtp_auth' => TRUE,     // or FALSE for anonymous relay
+        // 'from_name' => '',
+        // 'from_address' => '',
+        // 'reply_to' => '',
+        // 'wordwrap' => TRUE,
+        // 'wrapchars' => 76,
+        // 'mailtype' => 'html',    // or 'text'
+        // 'priority' => 3,
+        // 'bcc_batch_mode' => FALSE,
+        // 'bcc_batch_size' => 200,
+        // 'dsn' => FALSE
+        // 'crlf' => "\r\n",
+        // 'newline' => "\r\n",
+    ];
 
     // ------------------------------------------------------------------------
     // GOOGLE CALENDAR SYNC (Optional - can also be configured via UI)


### PR DESCRIPTION
- Extend database settings in userdefined `config.php`
- Maintain full backward compatibility with existing database configuration
- Move email settings from core configuration to userdefined `config.php`
- Improve configuration flexibility and customization
- Eliminate the need to restore email settings after future updates