### PR TITLE
ci: bump checkout to v4, add PHP version matrix, verify frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,19 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '8.2', '8.3', '8.4' ]
+
     steps:
       - name: Git clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: ${{ matrix.php-version }}
           extensions: gd
 
       - name: Install Composer dependencies
@@ -27,3 +32,27 @@ jobs:
 
       - name: Run PHPUnit
         run: vendor/bin/phpunit --configuration phpunit.xml
+
+  frontend-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: gd
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Verify frontend build
+        run: npm run build


### PR DESCRIPTION
Closes #1948

## Summary

- Bumps `actions/checkout` from v2 to v4
- Adds a PHP version matrix (8.2, 8.3, 8.4) to `build-test`, matching composer.json's declared `>=8.2` support range — CI only ever tested 8.3 before
- Adds a separate `frontend-build` job that installs npm dependencies and runs the real production build (`npm run build`), so a change that breaks the gulp build pipeline gets caught in CI rather than only discovered at release time

All CI-config-only changes, no application code touched.

## Testing

- Verified locally on PHP 8.3.6: `composer install`, `cp config-sample.php config.php`, `composer dump-autoload --no-interaction`, `vendor/bin/phpunit` — 24 tests, 32 assertions, all pass (exact steps CI runs)
- Verified `npm ci && npm run build` completes successfully (gulp build finishes clean)
- Didn't have PHP 8.2/8.4 available locally to test directly — relying on CI's matrix to confirm those, since this is a version-matrix addition rather than a behavioural change

## Note

Opened straight after #1948 rather than waiting for a reply first — happy to adjust anything based on feedback, this is very much up for discussion per CONTRIBUTING.md.