### PR TITLE
test: add PHPUnit coverage for Services_model::validate()

### DIFF
--- a/tests/Unit/Model/ServicesModelTest.php
+++ b/tests/Unit/Model/ServicesModelTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use Services_model;
+use Tests\TestCase;
+
+class ServicesModelTest extends TestCase
+{
+    private function services_model(): Services_model
+    {
+        // EA_Model extends CodeIgniter's CI_Model, which must be defined before EA_Model is parsed.
+        require_once BASEPATH . 'core/Model.php';
+        require_once APPPATH . 'core/EA_Model.php';
+        require_once APPPATH . 'models/Services_model.php';
+
+        // Matches application/config/constants.php -- defined here rather than requiring that
+        // file wholesale, which would clash with the DB_SLUG_* stand-ins tests/bootstrap.php
+        // already defines for the permission helper tests.
+        defined('EVENT_MINIMUM_DURATION') or define('EVENT_MINIMUM_DURATION', 5);
+
+        // The constructor only loads CodeIgniter model/DB dependencies that validate() does not
+        // need, as long as the "id"/"id_service_categories" keys (the only $this->db touches) are
+        // omitted from the payload.
+        return (new ReflectionClass(Services_model::class))->newInstanceWithoutConstructor();
+    }
+
+    public function testValidateThrowsWhenNameIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->services_model()->validate(['attendants_number' => 1]);
+    }
+
+    public function testValidateThrowsWhenDurationIsBelowTheMinimum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->services_model()->validate(['name' => 'Haircut', 'duration' => 2, 'attendants_number' => 1]);
+    }
+
+    public function testValidateThrowsWhenPriceIsNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->services_model()->validate(['name' => 'Haircut', 'price' => -5, 'attendants_number' => 1]);
+    }
+
+    public function testValidateThrowsWhenSlotIntervalIsBelowOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->services_model()->validate(['name' => 'Haircut', 'slot_interval' => 0, 'attendants_number' => 1]);
+    }
+
+    public function testValidateThrowsWhenAttendantsNumberIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->services_model()->validate(['name' => 'Haircut']);
+    }
+
+    public function testValidateThrowsWhenAttendantsNumberIsBelowOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->services_model()->validate(['name' => 'Haircut', 'attendants_number' => 0]);
+    }
+
+    public function testValidatePassesForAFullyValidPayload(): void
+    {
+        $this->services_model()->validate(['name' => 'Haircut', 'attendants_number' => 1]);
+
+        $this->assertTrue(true); // No exception thrown.
+    }
+}


### PR DESCRIPTION
## Summary

Adds `tests/Unit/Model/ServicesModelTest.php`, covering `Services_model::validate()` -- the request-body validation the REST API relies on before a service is saved.

Resolves #1952.

## Approach

Extends the `ReflectionClass::newInstanceWithoutConstructor()` pattern already established for `Availability`/`Timezones`/`Caldav_sync` (see #1951) to a model for the first time. `Services_model::validate()` doesn't call the DB-backed `setting()` helper anywhere (unlike `Appointments_model`/`Customers_model`), so its six field-validation branches are reachable in a plain unit test by simply omitting the optional `id`/`id_service_categories` keys -- the method's only two `$this->db` touches. No production code changed.

`EA_Model` extends CodeIgniter's `CI_Model`, so `system/core/Model.php` needs loading before `EA_Model.php` can be parsed; `EVENT_MINIMUM_DURATION` is defined locally (guarded with `defined()`) rather than requiring `application/config/constants.php` wholesale, which would clash with the `DB_SLUG_*` stand-ins `tests/bootstrap.php` already defines for the permission-helper tests.

## Notable test case

`testValidateThrowsWhenAttendantsNumberIsMissing` triggers a pre-existing PHP warning in production code: the "invalid attendants number" exception message interpolates `$service['attendants_number']` without an `isset()` check, so an entirely missing key (as opposed to an explicit `0`) reads as undefined. Not fixed here (test-only PR) -- flagging in case it's worth a tiny separate fix.

## Testing

`vendor/bin/phpunit --configuration phpunit.xml` -- full suite passes locally (42 tests, 73 assertions, the one expected warning above). New file also passes `npx prettier --check`.