### PR TITLE
Fix: HTMLPurifier cache write error

### DIFF
--- a/application/helpers/html_helper.php
+++ b/application/helpers/html_helper.php
@@ -189,6 +189,12 @@ if (!function_exists('pure_html')) {
     {
         $config = HTMLPurifier_Config::createDefault();
 
+        // By default, HTMLPurifier caches its serialized definitions inside its own vendor directory
+        // (vendor/ezyang/htmlpurifier/library/HTMLPurifier/DefinitionCache/Serializer), which is commonly
+        // deployed read-only or owned by a different user than the web server. Redirect it to storage/cache,
+        // the app's own writable data directory, to avoid write permission errors.
+        $config->set('Cache.SerializerPath', storage_path('cache'));
+
         $purifier = new HTMLPurifier($config);
 
         return $purifier->purify($markup);


### PR DESCRIPTION
By default, HTMLPurifier caches its serialized definitions inside its own
vendor directory (vendor/ezyang/htmlpurifier/library/HTMLPurifier/
DefinitionCache/Serializer), which is commonly deployed read-only or owned
by a different user than the web server - causing write permission errors.

HTMLPurifier is used in Easy!Appointments to validate text-based settings
where HTML is allowed, e.g. texts entered in Settings > Legal Contents >
Privacy Policy or Terms & Conditions. This error could then popup
whenever those texts were shown in the booking UI.

Fix: redirect the cache to storage/cache, the app's own writable data
directory, via storage_path().
