### PR TITLE
Fix: malformed time string when rendering non-working hours around a working plan exception

### DIFF
--- a/assets/js/utils/calendar_default_view.js
+++ b/assets/js/utils/calendar_default_view.js
@@ -1118,7 +1118,6 @@ App.Utils.CalendarDefaultView = (function () {
      */
     function createWorkHoursUnavailability(calendarDate, dayPlan, viewEnd) {
         const events = [];
-        const dateStr = calendarDate.format('YYYY-MM-DD');
 
         // Before work starts
         const [startHour, startMin] = dayPlan.start.split(':').map(Number);
@@ -1128,7 +1127,11 @@ App.Utils.CalendarDefaultView = (function () {
             events.push({
                 title: lang('not_working'),
                 start: calendarDate.clone().toDate(),
-                end: moment(dateStr + ' ' + dayPlan.start + ':00').toDate(),
+                // Reuse the already-parsed workStart rather than re-parsing dayPlan.start as a string: dayPlan.start
+                // may be "HH:mm:ss" (the raw MySQL TIME format returned by working plan exceptions fetched fresh
+                // from the server) rather than "HH:mm", and appending ":00" to the former produces a malformed
+                // 4-segment time string.
+                end: workStart.toDate(),
                 allDay: false,
                 color: EVENT_COLORS.notWorking,
                 editable: false,
@@ -1144,7 +1147,8 @@ App.Utils.CalendarDefaultView = (function () {
         if (viewEnd > workEnd.toDate()) {
             events.push({
                 title: lang('not_working'),
-                start: moment(dateStr + ' ' + dayPlan.end + ':00').toDate(),
+                // See the comment above workStart's usage - same reasoning applies here.
+                start: workEnd.toDate(),
                 end: calendarDate.clone().add(1, 'day').toDate(),
                 allDay: false,
                 color: EVENT_COLORS.notWorking,


### PR DESCRIPTION
After adding a working plan exception in calendar, navigating away from the
calendar and then back again, the whole day with the working plan exception is
shown as free (regardless of what was entered into the working plan exception).

When calculating the start and end times, the code formats the time string by
appending ":00" to the given time. The hours are shown correctly right after the
working plan exception is saved, because the UI passes the time format as
"HH:mm", so appending ":00" works fine. But when navigating away from and then
back to the calendar, the working plan exceptions are reloaded from the database,
and then the time format is "HH:mm:ss". Appending ":00" to this creates a malformed
time string.

The fix is done in assets/js/utils/calendar_default_view.js:

createWorkHoursUnavailability() already parses dayPlan.start/end into proper
moment objects (workStart/workEnd) a few lines above, for a format-tolerant
boundary check. But the actual event start/end timestamps were still built by
re-parsing the same value as a string via `dateStr + ' ' + dayPlan.start +
':00'`. dayPlan.start/end may be "HH:mm:ss" (the raw MySQL TIME format
returned by working plan exceptions fetched fresh from the server) rather
than "HH:mm", so appending ":00" to the former produces a malformed
4-segment time string.

Fix: reuse the already-correctly-parsed workStart/workEnd moments instead of
re-parsing the string a second time.