### PR TITLE
test: add PHPUnit coverage for the remaining DB-free validate() models

### DIFF
--- a/tests/Unit/Model/BlockedPeriodsModelTest.php
+++ b/tests/Unit/Model/BlockedPeriodsModelTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+use Blocked_periods_model;
+use InvalidArgumentException;
+use ReflectionClass;
+use Tests\TestCase;
+
+class BlockedPeriodsModelTest extends TestCase
+{
+    private function blocked_periods_model(): Blocked_periods_model
+    {
+        // EA_Model extends CodeIgniter's CI_Model, which must be defined before EA_Model is parsed.
+        require_once BASEPATH . 'core/Model.php';
+        require_once APPPATH . 'core/EA_Model.php';
+        require_once APPPATH . 'models/Blocked_periods_model.php';
+
+        // The constructor only loads CodeIgniter model/DB dependencies that validate() does not
+        // need, as long as the "id" key (the only $this->db touch) is omitted from the payload.
+        return (new ReflectionClass(Blocked_periods_model::class))->newInstanceWithoutConstructor();
+    }
+
+    public function testValidateThrowsWhenNameIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->blocked_periods_model()->validate([
+            'start_datetime' => '2026-01-01 09:00:00',
+            'end_datetime' => '2026-01-01 17:00:00',
+        ]);
+    }
+
+    public function testValidateThrowsWhenStartDatetimeIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->blocked_periods_model()->validate([
+            'name' => 'Holiday',
+            'end_datetime' => '2026-01-01 17:00:00',
+        ]);
+    }
+
+    public function testValidateThrowsWhenEndDatetimeIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->blocked_periods_model()->validate([
+            'name' => 'Holiday',
+            'start_datetime' => '2026-01-01 09:00:00',
+        ]);
+    }
+
+    public function testValidateThrowsWhenStartIsAfterEnd(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->blocked_periods_model()->validate([
+            'name' => 'Holiday',
+            'start_datetime' => '2026-01-01 17:00:00',
+            'end_datetime' => '2026-01-01 09:00:00',
+        ]);
+    }
+
+    public function testValidateThrowsWhenStartEqualsEnd(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->blocked_periods_model()->validate([
+            'name' => 'Holiday',
+            'start_datetime' => '2026-01-01 09:00:00',
+            'end_datetime' => '2026-01-01 09:00:00',
+        ]);
+    }
+
+    public function testValidatePassesForAFullyValidPayload(): void
+    {
+        $this->blocked_periods_model()->validate([
+            'name' => 'Holiday',
+            'start_datetime' => '2026-01-01 09:00:00',
+            'end_datetime' => '2026-01-01 17:00:00',
+        ]);
+
+        $this->assertTrue(true); // No exception thrown.
+    }
+}

--- a/tests/Unit/Model/ServiceCategoriesModelTest.php
+++ b/tests/Unit/Model/ServiceCategoriesModelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use Service_categories_model;
+use Tests\TestCase;
+
+class ServiceCategoriesModelTest extends TestCase
+{
+    private function service_categories_model(): Service_categories_model
+    {
+        // EA_Model extends CodeIgniter's CI_Model, which must be defined before EA_Model is parsed.
+        require_once BASEPATH . 'core/Model.php';
+        require_once APPPATH . 'core/EA_Model.php';
+        require_once APPPATH . 'models/Service_categories_model.php';
+
+        // The constructor only loads CodeIgniter model/DB dependencies that validate() does not
+        // need, as long as the "id" key (the only $this->db touch) is omitted from the payload.
+        return (new ReflectionClass(Service_categories_model::class))->newInstanceWithoutConstructor();
+    }
+
+    public function testValidateThrowsWhenNameIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->service_categories_model()->validate(['description' => 'Hair services']);
+    }
+
+    public function testValidatePassesForAFullyValidPayload(): void
+    {
+        $this->service_categories_model()->validate(['name' => 'Hair', 'description' => 'Hair services']);
+
+        $this->assertTrue(true); // No exception thrown.
+    }
+}

--- a/tests/Unit/Model/WorkingPlanExceptionsModelTest.php
+++ b/tests/Unit/Model/WorkingPlanExceptionsModelTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use Tests\TestCase;
+use Working_plan_exceptions_model;
+
+class WorkingPlanExceptionsModelTest extends TestCase
+{
+    private function working_plan_exceptions_model(): Working_plan_exceptions_model
+    {
+        // EA_Model extends CodeIgniter's CI_Model, which must be defined before EA_Model is parsed.
+        require_once BASEPATH . 'core/Model.php';
+        require_once APPPATH . 'core/EA_Model.php';
+        require_once APPPATH . 'models/Working_plan_exceptions_model.php';
+
+        // The constructor only loads CodeIgniter model/DB dependencies that validate() does not
+        // need, as long as the "id" key (the only $this->db touch) is omitted from the payload.
+        return (new ReflectionClass(Working_plan_exceptions_model::class))->newInstanceWithoutConstructor();
+    }
+
+    private function valid_payload(array $overrides = []): array
+    {
+        return array_merge(
+            [
+                'start_date' => '2026-01-01',
+                'end_date' => '2026-01-02',
+                'id_users_provider' => 1,
+            ],
+            $overrides,
+        );
+    }
+
+    public function testValidateThrowsWhenStartDateIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $payload = $this->valid_payload();
+        unset($payload['start_date']);
+
+        $this->working_plan_exceptions_model()->validate($payload);
+    }
+
+    public function testValidateThrowsWhenEndDateIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $payload = $this->valid_payload();
+        unset($payload['end_date']);
+
+        $this->working_plan_exceptions_model()->validate($payload);
+    }
+
+    public function testValidateThrowsWhenProviderIdIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $payload = $this->valid_payload();
+        unset($payload['id_users_provider']);
+
+        $this->working_plan_exceptions_model()->validate($payload);
+    }
+
+    public function testValidateThrowsWhenStartDateFormatIsInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->working_plan_exceptions_model()->validate($this->valid_payload(['start_date' => '01-01-2026']));
+    }
+
+    public function testValidateThrowsWhenEndDateFormatIsInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->working_plan_exceptions_model()->validate($this->valid_payload(['end_date' => '2026-13-40']));
+    }
+
+    public function testValidateThrowsWhenStartDateIsAfterEndDate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->working_plan_exceptions_model()->validate(
+            $this->valid_payload(['start_date' => '2026-01-05', 'end_date' => '2026-01-01']),
+        );
+    }
+
+    public function testValidatePassesWhenStartDateEqualsEndDate(): void
+    {
+        $this->working_plan_exceptions_model()->validate(
+            $this->valid_payload(['start_date' => '2026-01-01', 'end_date' => '2026-01-01']),
+        );
+
+        $this->assertTrue(true); // No exception thrown.
+    }
+
+    public function testValidateThrowsWhenStartTimeIsAfterEndTime(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->working_plan_exceptions_model()->validate(
+            $this->valid_payload(['start_time' => '17:00:00', 'end_time' => '09:00:00']),
+        );
+    }
+
+    public function testValidatePassesWhenStartOrEndTimeOmitted(): void
+    {
+        $this->working_plan_exceptions_model()->validate($this->valid_payload(['start_time' => '17:00:00']));
+
+        $this->assertTrue(true); // No exception thrown.
+    }
+
+    public function testValidatePassesForAFullyValidPayload(): void
+    {
+        $this->working_plan_exceptions_model()->validate(
+            $this->valid_payload(['start_time' => '09:00:00', 'end_time' => '17:00:00']),
+        );
+
+        $this->assertTrue(true); // No exception thrown.
+    }
+}


### PR DESCRIPTION
Closes #1960.

Extends the `Services_model::validate()` test tranche (#1952/#1953) to the other three `EA_Model` `validate()` methods whose only `$this->db` touch is the optional existing-ID lookup, reachable DB-free by omitting the `id` key:

- `Service_categories_model::validate()` — required `name` field
- `Blocked_periods_model::validate()` — required fields, start-before-end datetime ordering
- `Working_plan_exceptions_model::validate()` — required fields, `start_date`/`end_date` Y-m-d format validation, date ordering, optional `start_time`/`end_time` ordering

Same `newInstanceWithoutConstructor()` + reflection convention already used in `ServicesModelTest`/`AvailabilityTest`/`CaldavSyncTest`. Test-only, no production code changes. 18 new tests, full suite green (72/72 locally on PHP 8.3.6), formatted with `npx prettier --check`.